### PR TITLE
Keep the updater away from the install package

### DIFF
--- a/src/Utils/SystemUpdater.php
+++ b/src/Utils/SystemUpdater.php
@@ -142,6 +142,11 @@ class SystemUpdater
                     if (!str_ends_with($name, '.zip')) {
                         continue;
                     }
+                    // Install-Package (setup.php + Archiv für Erstinstallationen)
+                    // ist KEIN Update-Artefakt — enthält ein ZIP im ZIP.
+                    if (str_ends_with($name, '-install.zip')) {
+                        continue;
+                    }
                     if (str_starts_with($name, 'ignis-')) {
                         $pickedAsset = $asset;
                         break;


### PR DESCRIPTION
Follow-up to #296. The updater prefers `ignis-*.zip` release assets, and the new `ignis-<version>-install.zip` matches that prefix - depending on the asset order GitHub returns, an in-app update would have grabbed the install package (setup.php + nested archive) instead of the app archive. The asset loop now skips `-install.zip` explicitly. The standalone setup wizard got the same guard in EmergencyForge/intraRP-Setup@8b74f4c.