### PR TITLE
Footer version with an about dialog

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -169,7 +169,7 @@ jobs:
           cp "${{ env.archive_name }}" install-package/
 
           curl -fsSL -o install-package/setup.php \
-            https://raw.githubusercontent.com/EmergencyForge/intraRP-Setup/main/setup.php
+            https://raw.githubusercontent.com/EmergencyForge/ignis-setup/main/setup.php
           php -l install-package/setup.php
 
           cat > install-package/readme.txt << EOF

--- a/assets/components/footer.php
+++ b/assets/components/footer.php
@@ -1,4 +1,11 @@
 <!-- Footer für das Intranet-System -->
+<?php
+// Aktuelle Version aus storage/version.json (wird vom Release-Build bzw.
+// Updater gepflegt); fehlt die Datei, wird schlicht keine Version angezeigt.
+$__footerVersionFile = dirname(__DIR__, 2) . '/storage/version.json';
+$__footerVersionInfo = is_file($__footerVersionFile) ? json_decode((string) file_get_contents($__footerVersionFile), true) : null;
+$__footerVersion = is_array($__footerVersionInfo) && !empty($__footerVersionInfo['version']) ? (string) $__footerVersionInfo['version'] : null;
+?>
 <footer class="footer mt-auto py-3 text-white">
     <div class="container mx-auto">
         <div class="grid grid-cols-1 gap-3 items-end md:grid-cols-3">
@@ -8,6 +15,11 @@
             </div>
             <div class="text-center">
                 <p class="text-sm">&copy; 2024-<?php echo date("Y") ?> <em><strong>ıgnıs</strong></em> by <a href="https://emergencyforge.de" target="_blank" rel="nofollow">EmergencyForge</a>. Alle Rechte vorbehalten.</p>
+                <?php if ($__footerVersion !== null): ?>
+                    <button type="button" class="footer-version-btn" onclick="document.getElementById('ignis-about-dialog').showModal()" title="Über ıgnıs">
+                        <?= htmlspecialchars($__footerVersion) ?>
+                    </button>
+                <?php endif; ?>
             </div>
             <div class="md:text-right">
                 <?php
@@ -27,3 +39,91 @@
         </div>
     </div>
 </footer>
+
+<?php if ($__footerVersion !== null): ?>
+    <dialog id="ignis-about-dialog" class="ignis-about-dialog">
+        <div class="ignis-about-head">
+            <strong>ıgnıs <?= htmlspecialchars($__footerVersion) ?></strong>
+            <button type="button" onclick="this.closest('dialog').close()" aria-label="Schließen">✕</button>
+        </div>
+        <div class="ignis-about-body">
+            <p>
+                <em><strong>ıgnıs</strong></em> wird von
+                <a href="https://emergencyforge.de" target="_blank" rel="nofollow">EmergencyForge</a>
+                unter Mitarbeit von hypax, QuitScope, bitsystem und der Community entwickelt.
+            </p>
+            <p>
+                Lizenziert unter der
+                <a href="https://github.com/EmergencyForge/ignis/blob/main/LICENSE.md" target="_blank" rel="nofollow">GNU General Public License v3.0</a>
+                — Quellcode auf
+                <a href="https://github.com/EmergencyForge/ignis" target="_blank" rel="nofollow">GitHub</a>.
+            </p>
+        </div>
+    </dialog>
+    <style>
+        .footer-version-btn {
+            background: none;
+            border: none;
+            padding: 0;
+            font-size: 0.75rem;
+            color: rgba(255, 255, 255, 0.55);
+            cursor: pointer;
+            text-decoration: underline dotted;
+        }
+
+        .footer-version-btn:hover {
+            color: #fff;
+        }
+
+        .ignis-about-dialog {
+            margin: auto;
+            /* globale Resets nullen sonst das zentrierende UA-margin */
+            border: 1px solid rgba(255, 255, 255, 0.15);
+            border-radius: 10px;
+            background: #1c1c1e;
+            color: #e1e1e1;
+            padding: 0;
+            max-width: 26rem;
+            width: calc(100vw - 2rem);
+        }
+
+        .ignis-about-dialog::backdrop {
+            background: rgba(0, 0, 0, 0.6);
+        }
+
+        .ignis-about-head {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.75rem 1.25rem;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .ignis-about-head button {
+            background: none;
+            border: none;
+            color: #9a9a9a;
+            cursor: pointer;
+            font-size: 1rem;
+        }
+
+        .ignis-about-head button:hover {
+            color: #fff;
+        }
+
+        .ignis-about-body {
+            padding: 1rem 1.25rem 1.25rem;
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+
+        .ignis-about-body p+p {
+            margin-top: 0.75rem;
+        }
+
+        .ignis-about-body a {
+            color: inherit;
+            text-decoration: underline;
+        }
+    </style>
+<?php endif; ?>


### PR DESCRIPTION
The footer shows the running version (from `storage/version.json`) as a subtle dotted link under the copyright line. Clicking it opens a small dialog crediting EmergencyForge, the contributors (hypax, QuitScope, bitsystem) and the community, and links the GPL-3.0 license and the repository. Installs without a version.json render no button at all.

Also updates the release workflow to fetch the wizard from the renamed ignis-setup repo.