### PR TITLE
Plugin system: foundation (registry, manifest, resolution)

### DIFF
--- a/database/migrations/20260715000001_create_intra_plugins.php
+++ b/database/migrations/20260715000001_create_intra_plugins.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Plugin-Registrierung.
+ *
+ * Hält pro Plugin den installierten Zustand und ob es aktiv ist. Der
+ * PluginRegistry entdeckt Plugins über ihre `manifest.php` auf der Platte;
+ * diese Tabelle ist die Quelle der Wahrheit dafür, *welche* davon geladen
+ * werden. First-Party-Plugins mit `default_enabled` werden beim ersten
+ * Boot hier mit `enabled = 1` angelegt.
+ */
+class CreateIntraPlugins extends AbstractMigration
+{
+    public function change(): void
+    {
+        if ($this->hasTable('intra_plugins')) {
+            return;
+        }
+
+        $this->table('intra_plugins', ['id' => false, 'primary_key' => ['plugin_id']])
+            // Die stabile Plugin-ID aus dem Manifest (kein Auto-Increment,
+            // die ID selbst ist der natürliche Schlüssel).
+            ->addColumn('plugin_id', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('enabled', 'boolean', ['default' => true])
+            // Zuletzt gesehene Version des Manifests — erlaubt später,
+            // Plugin-Updates zu erkennen.
+            ->addColumn('installed_version', 'string', ['limit' => 32, 'null' => true])
+            ->addColumn('installed_at', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
+            ->addColumn('updated_at', 'timestamp', ['default' => 'CURRENT_TIMESTAMP', 'update' => 'CURRENT_TIMESTAMP'])
+            ->create();
+    }
+}

--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -1,0 +1,183 @@
+# Design: Plugin-System (First-Party-Modul-Extraktion)
+
+> Status: **Entwurf zur Diskussion** · Autor: EmergencyForge · Betrifft: `EmergencyForge/ignis`, `EmergencyForge/hub`
+
+## Zusammenfassung
+
+ignis bekommt ein Plugin-System. Der Einstieg ist **nicht** ein SDK für Dritte,
+sondern die Umwandlung der eigenen Module (eNOTF, fireTab, MANV, …) von fester
+Verdrahtung in **mitgelieferte First-Party-Plugins**. Sie bleiben standardmäßig
+vorinstalliert, sind aber architektonisch Plugins: einzeln aktivierbar/
+deaktivierbar und über eine stabile API in den Kern eingeklinkt.
+
+Getroffene Grundsatzentscheidungen:
+
+| Weiche | Entscheidung |
+|--------|--------------|
+| **Isolationsgrad** | Convention + Manifest — ein Plugin ist ein Ordner mit deklarativem Manifest, das sich in die vorhandenen Register einklinkt. Keine erzwungene Prozess-Sandbox. |
+| **Vertrauensmodell** | Kuratierter Katalog über den Hub. First-Party-Plugins sind signiert und vorinstalliert; Fremd-Plugins nur mit expliziter Entwickler-Freischaltung. |
+| **v1-Umfang** | Volle API-Oberfläche (Routen, Nav, Events senden + empfangen, Migrations, Permissions, Templates, Cron, Console, DI), validiert durch Extraktion der eigenen Module. |
+
+## Leitidee: Dogfooding statt Spekulation
+
+Ein Plugin-System, dessen API nur an Spielzeug-Beispielen entworfen wurde, bricht
+beim ersten echten Modul. Deshalb ist die erste „Kundschaft" der API ignis selbst:
+eNOTF emittiert Events (`EnotfProtocolReleased`), hat Cron-Jobs, viele Migrations
+und eigene Templates — wenn die Plugin-API *das* trägt, trägt sie auch alles, was
+später von Dritten kommt.
+
+Der spürbare Nutzen für Communities: **weniger Ballast.** Eine reine
+Rettungsdienst-Community deaktiviert fireTab, eine reine Feuerwehr eNOTF — die
+Navigation, die Berechtigungen und die Cron-Jobs des abgeschalteten Moduls
+verschwinden sauber.
+
+## Architektur: Kernel vs. Plugins
+
+Der Kern schrumpft auf einen **Kernel**, der die Infrastruktur stellt, an die sich
+Plugins hängen. Alles Fachliche wird Plugin.
+
+**Kernel (bleibt fest verdrahtet):**
+Auth/Session, Users & Roles, Permission-System, DI-Container, Router,
+Event-Dispatcher, AutoMigrator, Cron-Scheduler, Console-Application, Logging,
+Config, das Navigations-Gerüst (Rail/Flyout-Shell), Dashboard, Settings-Rahmen,
+SystemUpdater, Telemetrie/Hub-Client.
+
+**First-Party-Plugins (extrahiert, standardmäßig aktiv):**
+eNOTF, fireTab (Fire Incidents), MANV, Dokumente, Wissensdatenbank, Kalender,
+Fahrtenbuch, Fahrzeuge, Anträge, Föderation.
+
+> Grenzfall **Personal (Personnel):** eng mit Users/Roles verkoppelt. Kandidat,
+> im Kernel zu bleiben oder als „nicht-deaktivierbares Basis-Plugin" zu starten.
+> Zu entscheiden bei der Extraktion.
+
+## Plugin-Struktur & Manifest
+
+```
+plugins/enotf/
+  manifest.php        Metadaten, Kompatibilität, Abhängigkeiten, Permissions
+  routes.web.php      Fragment: web-Routen (bekommt $router)
+  routes.api.php      Fragment: API-Routen
+  navigation.php      Fragment: rail/section-Einträge (gemergt in die Shell)
+  events.php          Fragment: Event → Listener-Map
+  console.php         Fragment: Console-Command-Klassen
+  cron.php            Fragment: Cron-Job-Definitionen
+  migrations/         Eigene Phinx-Migrations (Prefix plugin_enotf_*)
+  templates/          Eigene Views
+  src/                Controller, Services, Listener (autowired)
+```
+
+Das Manifest ist die einzige Pflichtdatei:
+
+```php
+return [
+    'id'           => 'enotf',
+    'name'         => 'eNOTF – Notfallprotokolle',
+    'version'      => '1.0.0',
+    'vendor'       => 'EmergencyForge',
+    'requires'     => ['ignis' => '>=1.2 <2.0'],  // Kompatibilitätsbereich
+    'depends'      => [],                          // andere Plugin-IDs
+    'permissions'  => ['enotf.view', 'enotf.edit', 'enotf.admin'],
+    'default_enabled' => true,                     // vorinstalliert & aktiv
+    'removable'    => true,                        // darf deaktiviert werden
+];
+```
+
+## Der PluginLoader
+
+Ein `PluginLoader` läuft beim Bootstrap **vor** dem Aufbau der Register. Er:
+
+1. entdeckt alle Plugins unter `plugins/*/manifest.php`,
+2. filtert auf die in der DB als **aktiv** markierten (`intra_plugins`-Tabelle),
+3. prüft `requires` (ignis-Version) und `depends` (aktive Abhängigkeiten) und
+   deaktiviert bei Konflikt mit Warnung,
+4. speist die Fragmente in die schon vorhandenen Nahtstellen ein:
+
+| Nahtstelle heute | Plugin-Beitrag | Mechanik |
+|------------------|----------------|----------|
+| `routes/web.php`, `routes/api.php` | `routes.web.php` / `routes.api.php` | Loader `require`t die Fragmente mit demselben `$router` |
+| `config/navigation.php` | `navigation.php` | Fragmente werden in die Rail/Sections gemergt (Sortierung via `order`) |
+| `config/events.php` | `events.php` | Einträge werden in die Event→Listener-Map gemergt |
+| `config/console.php` | `console.php` | Command-Klassen werden an die Console-Registry angehängt |
+| Cron (`intra_cron_jobs`) | `cron.php` | Job-Definitionen werden beim Boot idempotent registriert |
+| `AutoMigrator` (`glob('database/migrations/*.php')`) | `migrations/` | Loader ergänzt aktive Plugin-Migrationspfade |
+| Container | `src/` (autowired) | Services werden per Autowiring aufgelöst; optional `services.php`-Fragment |
+| `config/permissions.php` | `manifest['permissions']` | Werden in den Permission-Katalog gemergt |
+
+Entscheidend: **Der Kern muss dafür kaum umgebaut werden.** Die Register sind
+heute schon Arrays bzw. glob-basiert — sie müssen nur „mergefähig" statt
+„fest" werden.
+
+## Inter-Plugin-Abhängigkeiten
+
+Module referenzieren sich teils (z. B. fireTab ↔ Fahrzeuge). Das Manifest
+deklariert `depends`. Der Loader:
+
+- aktiviert ein Plugin nur, wenn alle `depends` aktiv sind,
+- verweigert das Deaktivieren, solange ein aktives Plugin es braucht (mit klarer
+  Meldung „fireTab benötigt Fahrzeuge"),
+- lädt in topologischer Reihenfolge (Abhängigkeit zuerst).
+
+Fremdreferenzen laufen über **Events oder deklarierte Service-Interfaces**, nie
+über direkte Klassenzugriffe in fremde Plugin-`src/`.
+
+## Deaktivieren: Was passiert mit den Daten?
+
+Deaktivieren ≠ Deinstallieren.
+
+- **Deaktivieren:** Routen, Nav, Cron, Listener werden nicht geladen. **Tabellen
+  und Daten bleiben unangetastet.** Reaktivieren stellt alles wieder her.
+- **Deinstallieren (später, optional):** explizite Aktion mit Warnung; erst dann
+  könnten Plugin-Tabellen entfernt werden — mit vorherigem Export.
+
+Das schützt vor versehentlichem Datenverlust und macht Deaktivieren risikolos.
+
+## Der Hub als Plugin-Katalog
+
+Der gerade gebaute Hub wird zum kuratierten Register:
+
+- `GET /v1/plugins` — Liste kuratierter Plugins (id, version, Digest, min-ignis).
+- Der SystemUpdater zieht und verifiziert Plugins wie App-Updates (Digest-Check
+  ist bereits vorhanden).
+- Admin-UI in ignis: verfügbare Plugins, installiert/aktiv, Update verfügbar.
+- Fremd-Plugins nur über `?dev`-Freischaltung + deutliche Warnung
+  (Code-Ausführung mit vollen Rechten).
+
+## Migrationsplan (Phasen)
+
+**Phase 0 — Fundament.** `PluginLoader`, Manifest-Format, `intra_plugins`-Tabelle,
+Register „mergefähig" machen. Noch kein Modul extrahiert.
+
+**Phase 1 — Proof mit einem einfachen Modul.** Ein self-contained Modul zuerst
+extrahieren (Kandidat: **Fahrtenbuch** oder **Wissensdatenbank** — wenig
+Querbezüge), um Loader + Manifest an echtem Code zu validieren. CI muss grün
+bleiben.
+
+**Phase 2 — Flaggschiffe.** eNOTF und fireTab extrahieren (die komplexen Fälle
+mit Events, Cron, vielen Migrations). Danach die übrigen Module, je ein PR.
+
+**Phase 3 — Enable/Disable-UX + Hub-Katalog.** Admin-UI zum Schalten,
+`/v1/plugins` im Hub, Update-Fluss.
+
+**Phase 4 — Öffnung für Dritte.** Erst wenn die API durch die eigenen Module
+bewährt ist: dokumentierte Plugin-SDK, Fremd-Plugin-Freischaltung, ggf.
+Community-Einreichungen in den Katalog.
+
+## Offene Risiken
+
+- **Geteilter Code / Kopplung.** Module teilen heute vielleicht Helper/Models.
+  Vor der Extraktion inventarisieren; gemeinsam Genutztes wandert in den Kernel
+  oder ein Basis-Plugin.
+- **Migrations-Reihenfolge.** Plugin-Migrations müssen deterministisch nach den
+  Kernel-Migrations laufen; Namespacing (`plugin_<id>_*`) gegen Kollisionen.
+- **Kernel-Grenze.** Die Personnel-Frage exemplarisch: Wo genau verläuft die
+  Linie zwischen „Infrastruktur" und „Fachlichkeit"?
+- **Stabile Event-/Service-API.** Sobald Plugins an Kern-Events hängen, werden
+  diese zu Vertragspartnern — ein versionierter „öffentlicher" Event-Katalog ist
+  nötig, bevor Phase 4 startet.
+
+## Nicht-Ziele (v1)
+
+- Keine Prozess-/Sicherheits-Sandbox (bei self-hosted PHP illusorisch).
+- Kein Marktplatz mit Bezahlung/Reviews durch Dritte.
+- Keine Laufzeit-Installation ohne Neustart/Cache-Rebuild.
+- Keine Rückwärtskompatibilität für Fremd-Plugins vor Phase 4.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,43 @@
+# Plugins
+
+Hier liegen die installierten ignis-Plugins — je ein Unterordner mit einer
+`manifest.php`. Der `PluginRegistry` entdeckt sie beim Boot, der
+`PluginRepository` (Tabelle `intra_plugins`) entscheidet, welche aktiv sind.
+
+Die Module **eNOTF, fireTab, MANV-Board und Wissensdatenbank** werden als
+Plugins ausgeliefert; alle übrigen Funktionen sind fester Bestandteil des
+Cores. Details zum Aufbau: [docs/design/plugin-system.md](../docs/design/plugin-system.md).
+
+## Aufbau eines Plugins
+
+```
+plugins/<id>/
+  manifest.php        Pflicht: Metadaten, Kompatibilität, Abhängigkeiten
+  routes.web.php      optional: web-Routen (bekommt $router)
+  routes.api.php      optional: API-Routen
+  navigation.php      optional: Nav-Fragment (rail/sections)
+  events.php          optional: Event → Listener-Map
+  console.php         optional: Console-Command-Klassen
+  cron.php            optional: Cron-Job-Definitionen
+  migrations/         optional: eigene Phinx-Migrations (Prefix plugin_<id>_*)
+  templates/          optional: Views
+  src/                optional: Controller, Services (autowired)
+```
+
+Das Manifest ist die einzige Pflichtdatei:
+
+```php
+<?php
+
+return [
+    'id'              => 'enotf',
+    'name'            => 'eNOTF – Notfallprotokolle',
+    'version'         => '1.0.0',
+    'vendor'          => 'EmergencyForge',
+    'requires'        => ['ignis' => '>=1.2 <2.0'],
+    'depends'         => [],
+    'permissions'     => ['enotf.view', 'enotf.edit', 'enotf.admin'],
+    'default_enabled' => true,
+    'removable'       => true,
+];
+```

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -6,7 +6,7 @@ Hier liegen die installierten ignis-Plugins — je ein Unterordner mit einer
 
 Die Module **eNOTF, fireTab, MANV-Board und Wissensdatenbank** werden als
 Plugins ausgeliefert; alle übrigen Funktionen sind fester Bestandteil des
-Cores. Details zum Aufbau: [docs/design/plugin-system.md](../docs/design/plugin-system.md).
+Cores.
 
 ## Aufbau eines Plugins
 

--- a/src/Plugins/Plugin.php
+++ b/src/Plugins/Plugin.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plugins;
+
+/**
+ * Ein auf der Platte entdecktes Plugin: sein Manifest plus der Ordner, in
+ * dem es liegt. Über die Pfad-Helfer greifen der Loader und die
+ * Register-Merger auf die einzelnen Fragmente zu (routes, navigation,
+ * events, migrations, …).
+ */
+final class Plugin
+{
+    public function __construct(
+        public readonly PluginManifest $manifest,
+        public readonly string $directory,
+    ) {}
+
+    public function id(): string
+    {
+        return $this->manifest->id;
+    }
+
+    /**
+     * Absoluter Pfad zu einer Datei im Plugin-Ordner, oder null wenn sie
+     * nicht existiert. So können optionale Fragmente (ein Plugin ohne
+     * Cron-Jobs hat keine cron.php) sauber übersprungen werden.
+     */
+    public function path(string $relative): ?string
+    {
+        $full = $this->directory . DIRECTORY_SEPARATOR . ltrim($relative, '/\\');
+        return is_file($full) ? $full : null;
+    }
+
+    /**
+     * Verzeichnis im Plugin, oder null wenn nicht vorhanden (z.B. migrations/).
+     */
+    public function dir(string $relative): ?string
+    {
+        $full = $this->directory . DIRECTORY_SEPARATOR . ltrim($relative, '/\\');
+        return is_dir($full) ? $full : null;
+    }
+}

--- a/src/Plugins/PluginManifest.php
+++ b/src/Plugins/PluginManifest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plugins;
+
+use InvalidArgumentException;
+
+/**
+ * Typisierte, validierte Repräsentation einer Plugin-`manifest.php`.
+ *
+ * Ein Manifest ist die einzige Pflichtdatei eines Plugins. Es liefert die
+ * Metadaten, die der PluginRegistry braucht, um Kompatibilität und
+ * Abhängigkeiten aufzulösen, bevor irgendein Plugin-Code geladen wird.
+ *
+ * Beispiel (plugins/enotf/manifest.php):
+ *
+ *     return [
+ *         'id'              => 'enotf',
+ *         'name'            => 'eNOTF – Notfallprotokolle',
+ *         'version'         => '1.0.0',
+ *         'vendor'          => 'EmergencyForge',
+ *         'requires'        => ['ignis' => '>=1.2 <2.0'],
+ *         'depends'         => [],
+ *         'permissions'     => ['enotf.view', 'enotf.edit', 'enotf.admin'],
+ *         'default_enabled' => true,
+ *         'removable'       => true,
+ *     ];
+ */
+final class PluginManifest
+{
+    /**
+     * @param string        $id            Eindeutige, stabile Plugin-ID (kebab/snake, [a-z0-9_-])
+     * @param string        $name          Menschlich lesbarer Anzeigename
+     * @param string        $version       Semver-Version des Plugins
+     * @param string        $vendor        Herausgeber (z.B. "EmergencyForge")
+     * @param string        $ignisRequire  Kompatibilitätsbereich zur ignis-Version
+     * @param list<string>  $depends       IDs anderer Plugins, die aktiv sein müssen
+     * @param list<string>  $permissions   Permissions, die dieses Plugin einbringt
+     * @param bool          $defaultEnabled Bei Erstinstallation direkt aktiv?
+     * @param bool          $removable      Darf der Nutzer es deaktivieren?
+     */
+    private function __construct(
+        public readonly string $id,
+        public readonly string $name,
+        public readonly string $version,
+        public readonly string $vendor,
+        public readonly string $ignisRequire,
+        public readonly array $depends,
+        public readonly array $permissions,
+        public readonly bool $defaultEnabled,
+        public readonly bool $removable,
+    ) {}
+
+    /**
+     * Baut ein Manifest aus dem rohen Array (Rückgabewert von manifest.php).
+     *
+     * @param array<array-key, mixed> $data
+     * @throws InvalidArgumentException wenn Pflichtfelder fehlen/ungültig sind
+     */
+    public static function fromArray(array $data): self
+    {
+        $id = self::requireString($data, 'id');
+        if (!preg_match('/^[a-z0-9][a-z0-9_-]*$/', $id)) {
+            throw new InvalidArgumentException("Plugin-ID '{$id}' ist ungültig (erlaubt: a-z, 0-9, _, -).");
+        }
+
+        $version = self::requireString($data, 'version');
+        $requires = $data['requires'] ?? [];
+        if (!is_array($requires)) {
+            throw new InvalidArgumentException("Plugin '{$id}': 'requires' muss ein Array sein.");
+        }
+
+        return new self(
+            id: $id,
+            name: self::requireString($data, 'name'),
+            version: $version,
+            vendor: isset($data['vendor']) ? (string) $data['vendor'] : 'Unbekannt',
+            ignisRequire: isset($requires['ignis']) ? (string) $requires['ignis'] : '*',
+            depends: self::stringList($data['depends'] ?? []),
+            permissions: self::stringList($data['permissions'] ?? []),
+            defaultEnabled: (bool) ($data['default_enabled'] ?? false),
+            removable: (bool) ($data['removable'] ?? true),
+        );
+    }
+
+    /**
+     * Ist dieses Plugin mit der laufenden ignis-Version kompatibel?
+     */
+    public function isCompatibleWith(string $ignisVersion): bool
+    {
+        return VersionConstraint::satisfies($ignisVersion, $this->ignisRequire);
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    private static function requireString(array $data, string $key): string
+    {
+        $value = $data[$key] ?? null;
+        if (!is_string($value) || trim($value) === '') {
+            throw new InvalidArgumentException("Plugin-Manifest: Pflichtfeld '{$key}' fehlt oder ist leer.");
+        }
+        return trim($value);
+    }
+
+    /**
+     * @param mixed $value
+     * @return list<string>
+     */
+    private static function stringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        return array_values(array_map(static fn ($v): string => (string) $v, $value));
+    }
+}

--- a/src/Plugins/PluginRegistry.php
+++ b/src/Plugins/PluginRegistry.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plugins;
+
+/**
+ * Entdeckt Plugins auf der Platte und löst auf, welche davon aktiv sind.
+ *
+ * Ein Plugin ist aktiv, wenn ALLE gelten:
+ *   1. es ist in der DB als aktiviert markiert (enabled-Set),
+ *   2. sein `requires: ignis` passt zur laufenden ignis-Version,
+ *   3. alle `depends` sind selbst aktiv (transitiv).
+ *
+ * Nicht erfüllte Bedingungen führen nicht zum Fehler, sondern zum
+ * Überspringen mit einem nachvollziehbaren Grund (siehe skipped()). So
+ * bootet ignis auch dann sauber, wenn ein einzelnes Plugin inkompatibel
+ * ist. Aktive Plugins werden in Abhängigkeitsreihenfolge zurückgegeben
+ * (Abhängigkeit vor Abhängigem), damit die Register-Merger deterministisch
+ * arbeiten.
+ */
+final class PluginRegistry
+{
+    /** @var array<string, Plugin> discovered plugins keyed by id */
+    private array $discovered;
+
+    /** @var list<Plugin> resolved active plugins in load order */
+    private array $active = [];
+
+    /** @var list<array{id: string, reason: string}> */
+    private array $skipped = [];
+
+    /**
+     * @param array<string, Plugin> $discovered
+     */
+    public function __construct(array $discovered)
+    {
+        $this->discovered = $discovered;
+    }
+
+    /**
+     * Scannt ein Plugins-Verzeichnis (`plugins/<id>/manifest.php`). Ordner
+     * ohne Manifest werden ignoriert; ein defektes Manifest wird als
+     * übersprungen vermerkt statt den Boot zu sprengen.
+     */
+    public static function fromDirectory(string $pluginsDir): self
+    {
+        $discovered = [];
+        $skipped = [];
+
+        foreach (glob($pluginsDir . '/*/manifest.php') ?: [] as $manifestFile) {
+            $dir = dirname($manifestFile);
+            try {
+                $data = require $manifestFile;
+                if (!is_array($data)) {
+                    throw new \InvalidArgumentException('manifest.php gibt kein Array zurück.');
+                }
+                $manifest = PluginManifest::fromArray($data);
+                $discovered[$manifest->id] = new Plugin($manifest, $dir);
+            } catch (\Throwable $e) {
+                $skipped[] = ['id' => basename($dir), 'reason' => 'Ungültiges Manifest: ' . $e->getMessage()];
+            }
+        }
+
+        $registry = new self($discovered);
+        $registry->skipped = $skipped;
+        return $registry;
+    }
+
+    /**
+     * Berechnet das aktive Set für die gegebenen aktivierten IDs und die
+     * laufende ignis-Version. Idempotent — kann erneut mit anderem Set
+     * aufgerufen werden.
+     *
+     * @param list<string> $enabledIds
+     */
+    public function resolve(array $enabledIds, string $ignisVersion): void
+    {
+        $this->active = [];
+        $enabled = array_fill_keys($enabledIds, true);
+
+        // 1) Kandidaten: entdeckt UND aktiviert.
+        $candidates = [];
+        foreach ($this->discovered as $id => $plugin) {
+            if (!isset($enabled[$id])) {
+                continue; // deaktiviert — kein Skip-Grund, bewusst aus
+            }
+            if (!$plugin->manifest->isCompatibleWith($ignisVersion)) {
+                $this->skipped[] = [
+                    'id' => $id,
+                    'reason' => "Benötigt ignis {$plugin->manifest->ignisRequire}, läuft auf {$ignisVersion}.",
+                ];
+                continue;
+            }
+            $candidates[$id] = $plugin;
+        }
+
+        // 2) Kaskadierend Kandidaten entfernen, deren Abhängigkeiten fehlen.
+        do {
+            $removed = false;
+            foreach ($candidates as $id => $plugin) {
+                foreach ($plugin->manifest->depends as $dep) {
+                    if (!isset($candidates[$dep])) {
+                        $reason = isset($this->discovered[$dep])
+                            ? "Abhängigkeit '{$dep}' ist nicht aktiv."
+                            : "Abhängigkeit '{$dep}' ist nicht installiert.";
+                        $this->skipped[] = ['id' => $id, 'reason' => $reason];
+                        unset($candidates[$id]);
+                        $removed = true;
+                        break;
+                    }
+                }
+            }
+        } while ($removed);
+
+        // 3) Topologisch sortieren (Kahn): Abhängigkeiten zuerst.
+        $this->active = $this->topologicalSort($candidates);
+    }
+
+    /**
+     * @param array<string, Plugin> $candidates
+     * @return list<Plugin>
+     */
+    private function topologicalSort(array $candidates): array
+    {
+        $sorted = [];
+        $visited = [];
+
+        // Deterministische Reihenfolge über alphabetische ID-Sortierung.
+        $ids = array_keys($candidates);
+        sort($ids);
+
+        foreach ($ids as $id) {
+            $this->visit($id, $candidates, [], $visited, $sorted);
+        }
+
+        return $sorted;
+    }
+
+    /**
+     * Tiefensuche für die topologische Sortierung. Besuchte Knoten werden
+     * markiert; ein Knoten, der bereits im aktuellen Pfad liegt, zeigt einen
+     * Zyklus an und wird mit Grund übersprungen.
+     *
+     * @param array<string, Plugin> $candidates
+     * @param list<string>          $trail
+     * @param array<string, true>   $visited
+     * @param list<Plugin>          $sorted
+     */
+    private function visit(string $id, array $candidates, array $trail, array &$visited, array &$sorted): void
+    {
+        if (isset($visited[$id])) {
+            return;
+        }
+        if (in_array($id, $trail, true)) {
+            $this->skipped[] = [
+                'id' => $id,
+                'reason' => 'Zyklische Abhängigkeit: ' . implode(' → ', [...$trail, $id]),
+            ];
+            return;
+        }
+
+        $deps = $candidates[$id]->manifest->depends;
+        sort($deps);
+        foreach ($deps as $dep) {
+            if (isset($candidates[$dep])) {
+                $this->visit($dep, $candidates, [...$trail, $id], $visited, $sorted);
+            }
+        }
+
+        $visited[$id] = true;
+        $sorted[] = $candidates[$id];
+    }
+
+    /**
+     * Aktive Plugins in Ladereihenfolge.
+     *
+     * @return list<Plugin>
+     */
+    public function active(): array
+    {
+        return $this->active;
+    }
+
+    /**
+     * Alle entdeckten Plugins (unabhängig vom Aktiv-Status).
+     *
+     * @return array<string, Plugin>
+     */
+    public function all(): array
+    {
+        return $this->discovered;
+    }
+
+    public function get(string $id): ?Plugin
+    {
+        return $this->discovered[$id] ?? null;
+    }
+
+    /**
+     * Diagnose: welche Plugins wurden warum übersprungen.
+     *
+     * @return list<array{id: string, reason: string}>
+     */
+    public function skipped(): array
+    {
+        return $this->skipped;
+    }
+}

--- a/src/Plugins/PluginRepository.php
+++ b/src/Plugins/PluginRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plugins;
+
+use PDO;
+
+/**
+ * DB-Zugriff auf den Aktiv-Status der Plugins (Tabelle `intra_plugins`).
+ *
+ * Trennt die reine Auflösungslogik (PluginRegistry, voll unit-testbar) von
+ * der Persistenz. Beim ersten Kontakt mit einem entdeckten Plugin wird ein
+ * Zeilen-Eintrag angelegt — `default_enabled` aus dem Manifest bestimmt,
+ * ob es direkt aktiv ist (so sind eNOTF & fireTab nach dem Update sofort
+ * da, ohne dass jemand sie manuell einschalten muss).
+ */
+final class PluginRepository
+{
+    public function __construct(
+        private readonly PDO $pdo,
+    ) {}
+
+    /**
+     * Sorgt dafür, dass jedes entdeckte Plugin eine Zeile hat. Neue Plugins
+     * bekommen `enabled` gemäß `default_enabled`. Bestehende Zeilen bleiben
+     * unangetastet — eine bewusste Nutzer-Deaktivierung wird nie überschrieben.
+     *
+     * @param array<string, Plugin> $discovered
+     */
+    public function syncDiscovered(array $discovered): void
+    {
+        $stmt = $this->pdo->query('SELECT plugin_id FROM intra_plugins');
+        $existing = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_COLUMN);
+        $known = array_fill_keys($existing, true);
+
+        $insert = $this->pdo->prepare(
+            'INSERT INTO intra_plugins (plugin_id, enabled, installed_version)
+             VALUES (:id, :enabled, :version)'
+        );
+
+        foreach ($discovered as $id => $plugin) {
+            if (isset($known[$id])) {
+                continue;
+            }
+            $insert->execute([
+                'id' => $id,
+                'enabled' => $plugin->manifest->defaultEnabled ? 1 : 0,
+                'version' => $plugin->manifest->version,
+            ]);
+        }
+    }
+
+    /**
+     * IDs aller aktivierten Plugins.
+     *
+     * @return list<string>
+     */
+    public function enabledIds(): array
+    {
+        $rows = $this->pdo->query('SELECT plugin_id FROM intra_plugins WHERE enabled = 1')->fetchAll(PDO::FETCH_COLUMN);
+        return array_values(array_map('strval', $rows));
+    }
+
+    public function setEnabled(string $pluginId, bool $enabled): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE intra_plugins SET enabled = :enabled WHERE plugin_id = :id');
+        $stmt->execute(['enabled' => $enabled ? 1 : 0, 'id' => $pluginId]);
+    }
+}

--- a/src/Plugins/VersionConstraint.php
+++ b/src/Plugins/VersionConstraint.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plugins;
+
+/**
+ * Minimaler Semver-Constraint-Matcher für Plugin-Manifeste.
+ *
+ * Es gibt bewusst keine composer/semver-Abhängigkeit — der Bedarf ist
+ * klein: ein Plugin sagt `requires: ['ignis' => '>=1.2 <2.0']`, und der
+ * PluginRegistry muss prüfen, ob die laufende ignis-Version dazu passt.
+ *
+ * Unterstützt werden mit Leerzeichen verknüpfte UND-Bedingungen, jeweils
+ * mit einem Operator:
+ *
+ *   >=1.2 <2.0     (mind. 1.2, aber kleiner als 2.0)
+ *   ^1.2           (>=1.2, <2.0 — gleiche Major)
+ *   ~1.2.3         (>=1.2.3, <1.3.0 — gleiche Minor)
+ *   =1.0.0         (exakt)
+ *   *              (beliebig)
+ *
+ * Versionsvergleich läuft über PHP's version_compare(), führende „v" in
+ * Version wie Constraint werden abgeschnitten.
+ */
+final class VersionConstraint
+{
+    /**
+     * Erfüllt $version alle Bedingungen aus $constraint?
+     */
+    public static function satisfies(string $version, string $constraint): bool
+    {
+        $version = self::normalize($version);
+        $constraint = trim($constraint);
+
+        if ($constraint === '' || $constraint === '*') {
+            return true;
+        }
+
+        // Mit Leerzeichen getrennte Teilbedingungen sind UND-verknüpft.
+        foreach (preg_split('/\s+/', $constraint) ?: [] as $part) {
+            if ($part === '' || !self::satisfiesPart($version, $part)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static function satisfiesPart(string $version, string $part): bool
+    {
+        // Caret: ^1.2.3 → >=1.2.3 <2.0.0 (nächste Major)
+        if (str_starts_with($part, '^')) {
+            $base = self::normalize(substr($part, 1));
+            $upper = (self::segment($base, 0) + 1) . '.0.0';
+            return version_compare($version, $base, '>=') && version_compare($version, $upper, '<');
+        }
+
+        // Tilde: ~1.2.3 → >=1.2.3 <1.3.0 (nächste Minor)
+        if (str_starts_with($part, '~')) {
+            $base = self::normalize(substr($part, 1));
+            $upper = self::segment($base, 0) . '.' . (self::segment($base, 1) + 1) . '.0';
+            return version_compare($version, $base, '>=') && version_compare($version, $upper, '<');
+        }
+
+        foreach (['>=', '<=', '==', '!=', '=', '>', '<'] as $op) {
+            if (str_starts_with($part, $op)) {
+                $target = self::normalize(substr($part, strlen($op)));
+                $cmpOp = $op === '=' ? '==' : $op;
+                return version_compare($version, $target, $cmpOp);
+            }
+        }
+
+        // Kein Operator → exakter Match.
+        return version_compare($version, self::normalize($part), '==');
+    }
+
+    private static function normalize(string $version): string
+    {
+        return ltrim(trim($version), 'vV');
+    }
+
+    /** Numerischer Wert des n-ten Punkt-Segments (fehlend = 0). */
+    private static function segment(string $version, int $index): int
+    {
+        $parts = explode('.', $version);
+        return isset($parts[$index]) ? (int) $parts[$index] : 0;
+    }
+}

--- a/tests/Unit/Plugins/PluginManifestTest.php
+++ b/tests/Unit/Plugins/PluginManifestTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Plugins;
+
+use App\Plugins\PluginManifest;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PluginManifestTest extends TestCase
+{
+    /**
+     * @return array<string,mixed>
+     */
+    private function validData(): array
+    {
+        return [
+            'id' => 'enotf',
+            'name' => 'eNOTF – Notfallprotokolle',
+            'version' => '1.0.0',
+            'vendor' => 'EmergencyForge',
+            'requires' => ['ignis' => '>=1.2 <2.0'],
+            'depends' => ['vehicles'],
+            'permissions' => ['enotf.view', 'enotf.edit'],
+            'default_enabled' => true,
+            'removable' => true,
+        ];
+    }
+
+    #[Test]
+    public function it_parses_a_valid_manifest(): void
+    {
+        $m = PluginManifest::fromArray($this->validData());
+
+        $this->assertSame('enotf', $m->id);
+        $this->assertSame('eNOTF – Notfallprotokolle', $m->name);
+        $this->assertSame('1.0.0', $m->version);
+        $this->assertSame('EmergencyForge', $m->vendor);
+        $this->assertSame('>=1.2 <2.0', $m->ignisRequire);
+        $this->assertSame(['vehicles'], $m->depends);
+        $this->assertSame(['enotf.view', 'enotf.edit'], $m->permissions);
+        $this->assertTrue($m->defaultEnabled);
+        $this->assertTrue($m->removable);
+    }
+
+    #[Test]
+    public function it_applies_sensible_defaults(): void
+    {
+        $m = PluginManifest::fromArray([
+            'id' => 'minimal',
+            'name' => 'Minimal',
+            'version' => '0.1.0',
+        ]);
+
+        $this->assertSame('Unbekannt', $m->vendor);
+        $this->assertSame('*', $m->ignisRequire);
+        $this->assertSame([], $m->depends);
+        $this->assertSame([], $m->permissions);
+        $this->assertFalse($m->defaultEnabled);
+        $this->assertTrue($m->removable, 'removable defaults to true');
+    }
+
+    #[Test]
+    public function it_rejects_a_missing_id(): void
+    {
+        $data = $this->validData();
+        unset($data['id']);
+
+        $this->expectException(InvalidArgumentException::class);
+        PluginManifest::fromArray($data);
+    }
+
+    #[Test]
+    public function it_rejects_an_invalid_id(): void
+    {
+        $data = $this->validData();
+        $data['id'] = 'Not Valid!';
+
+        $this->expectException(InvalidArgumentException::class);
+        PluginManifest::fromArray($data);
+    }
+
+    #[Test]
+    public function it_rejects_a_blank_name(): void
+    {
+        $data = $this->validData();
+        $data['name'] = '   ';
+
+        $this->expectException(InvalidArgumentException::class);
+        PluginManifest::fromArray($data);
+    }
+
+    #[Test]
+    public function it_checks_ignis_compatibility(): void
+    {
+        $m = PluginManifest::fromArray($this->validData());
+
+        $this->assertTrue($m->isCompatibleWith('1.5.0'));
+        $this->assertFalse($m->isCompatibleWith('2.0.0'));
+        $this->assertFalse($m->isCompatibleWith('1.0.0'));
+    }
+}

--- a/tests/Unit/Plugins/PluginRegistryTest.php
+++ b/tests/Unit/Plugins/PluginRegistryTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Plugins;
+
+use App\Plugins\Plugin;
+use App\Plugins\PluginManifest;
+use App\Plugins\PluginRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PluginRegistryTest extends TestCase
+{
+    /**
+     * @param list<string> $depends
+     */
+    private function plugin(string $id, array $depends = [], string $ignisRequire = '*'): Plugin
+    {
+        $manifest = PluginManifest::fromArray([
+            'id' => $id,
+            'name' => ucfirst($id),
+            'version' => '1.0.0',
+            'requires' => ['ignis' => $ignisRequire],
+            'depends' => $depends,
+        ]);
+        return new Plugin($manifest, '/virtual/' . $id);
+    }
+
+    /**
+     * @param list<Plugin> $plugins
+     * @return array<string, Plugin>
+     */
+    private function keyed(array $plugins): array
+    {
+        $out = [];
+        foreach ($plugins as $p) {
+            $out[$p->id()] = $p;
+        }
+        return $out;
+    }
+
+    /**
+     * @param list<Plugin> $active
+     * @return list<string>
+     */
+    private function ids(array $active): array
+    {
+        return array_map(static fn (Plugin $p): string => $p->id(), $active);
+    }
+
+    #[Test]
+    public function it_activates_enabled_and_compatible_plugins(): void
+    {
+        $registry = new PluginRegistry($this->keyed([
+            $this->plugin('enotf'),
+            $this->plugin('firetab'),
+        ]));
+
+        $registry->resolve(['enotf', 'firetab'], '1.5.0');
+
+        $this->assertSame(['enotf', 'firetab'], $this->ids($registry->active()));
+        $this->assertSame([], $registry->skipped());
+    }
+
+    #[Test]
+    public function it_ignores_disabled_plugins_without_a_skip_reason(): void
+    {
+        $registry = new PluginRegistry($this->keyed([
+            $this->plugin('enotf'),
+            $this->plugin('firetab'),
+        ]));
+
+        $registry->resolve(['enotf'], '1.5.0');
+
+        $this->assertSame(['enotf'], $this->ids($registry->active()));
+        // firetab is simply off, not an error
+        $this->assertSame([], $registry->skipped());
+    }
+
+    #[Test]
+    public function it_skips_version_incompatible_plugins(): void
+    {
+        $registry = new PluginRegistry($this->keyed([
+            $this->plugin('enotf', [], '>=2.0'),
+        ]));
+
+        $registry->resolve(['enotf'], '1.5.0');
+
+        $this->assertSame([], $registry->active());
+        $skipped = $registry->skipped();
+        $this->assertCount(1, $skipped);
+        $this->assertSame('enotf', $skipped[0]['id']);
+        $this->assertStringContainsString('ignis', $skipped[0]['reason']);
+    }
+
+    #[Test]
+    public function it_orders_dependencies_before_dependents(): void
+    {
+        $registry = new PluginRegistry($this->keyed([
+            $this->plugin('firetab', ['vehicles']),
+            $this->plugin('vehicles'),
+        ]));
+
+        $registry->resolve(['firetab', 'vehicles'], '1.5.0');
+
+        $order = $this->ids($registry->active());
+        $this->assertSame(['vehicles', 'firetab'], $order);
+    }
+
+    #[Test]
+    public function it_skips_a_plugin_whose_dependency_is_disabled(): void
+    {
+        $registry = new PluginRegistry($this->keyed([
+            $this->plugin('firetab', ['vehicles']),
+            $this->plugin('vehicles'),
+        ]));
+
+        // vehicles installed but not enabled
+        $registry->resolve(['firetab'], '1.5.0');
+
+        $this->assertSame([], $this->ids($registry->active()));
+        $reasons = $registry->skipped();
+        $this->assertCount(1, $reasons);
+        $this->assertSame('firetab', $reasons[0]['id']);
+        $this->assertStringContainsString('nicht aktiv', $reasons[0]['reason']);
+    }
+
+    #[Test]
+    public function it_skips_a_plugin_whose_dependency_is_not_installed(): void
+    {
+        $registry = new PluginRegistry($this->keyed([
+            $this->plugin('firetab', ['vehicles']),
+        ]));
+
+        $registry->resolve(['firetab'], '1.5.0');
+
+        $this->assertSame([], $this->ids($registry->active()));
+        $reasons = $registry->skipped();
+        $this->assertStringContainsString('nicht installiert', $reasons[0]['reason']);
+    }
+
+    #[Test]
+    public function it_cascades_dependency_removal(): void
+    {
+        // c depends on b depends on a; a is incompatible → all three drop
+        $registry = new PluginRegistry($this->keyed([
+            $this->plugin('a', [], '>=9.0'),
+            $this->plugin('b', ['a']),
+            $this->plugin('c', ['b']),
+        ]));
+
+        $registry->resolve(['a', 'b', 'c'], '1.5.0');
+
+        $this->assertSame([], $this->ids($registry->active()));
+        $this->assertCount(3, $registry->skipped());
+    }
+
+    #[Test]
+    public function it_detects_dependency_cycles(): void
+    {
+        $registry = new PluginRegistry($this->keyed([
+            $this->plugin('a', ['b']),
+            $this->plugin('b', ['a']),
+        ]));
+
+        $registry->resolve(['a', 'b'], '1.5.0');
+
+        $this->assertSame([], $this->ids($registry->active()));
+        $reasons = array_map(static fn ($s) => $s['reason'], $registry->skipped());
+        $this->assertNotEmpty(array_filter($reasons, static fn ($r) => str_contains($r, 'Zyklische')));
+    }
+
+    #[Test]
+    public function it_discovers_plugins_from_a_directory_and_skips_broken_ones(): void
+    {
+        $registry = PluginRegistry::fromDirectory(__DIR__ . '/fixtures/plugins');
+
+        $this->assertArrayHasKey('good', $registry->all());
+        $this->assertArrayNotHasKey('broken', $registry->all());
+
+        $skipped = $registry->skipped();
+        $this->assertCount(1, $skipped);
+        $this->assertSame('broken', $skipped[0]['id']);
+        $this->assertStringContainsString('Manifest', $skipped[0]['reason']);
+    }
+}

--- a/tests/Unit/Plugins/VersionConstraintTest.php
+++ b/tests/Unit/Plugins/VersionConstraintTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Plugins;
+
+use App\Plugins\VersionConstraint;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class VersionConstraintTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('cases')]
+    public function it_matches_versions_against_constraints(string $version, string $constraint, bool $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            VersionConstraint::satisfies($version, $constraint),
+            "'{$version}' satisfies '{$constraint}' should be " . ($expected ? 'true' : 'false')
+        );
+    }
+
+    /**
+     * @return list<array{0: string, 1: string, 2: bool}>
+     */
+    public static function cases(): array
+    {
+        return [
+            // wildcard / empty
+            ['1.0.0', '*', true],
+            ['1.0.0', '', true],
+
+            // range (AND of two parts) — the manifest's typical form
+            ['1.2.0', '>=1.2 <2.0', true],
+            ['1.5.9', '>=1.2 <2.0', true],
+            ['1.1.9', '>=1.2 <2.0', false],
+            ['2.0.0', '>=1.2 <2.0', false],
+            ['2.1.0', '>=1.2 <2.0', false],
+
+            // single operators
+            ['1.3.0', '>=1.3.0', true],
+            ['1.2.9', '>=1.3.0', false],
+            ['1.3.0', '>1.2.0', true],
+            ['1.2.0', '>1.2.0', false],
+            ['1.0.0', '<=1.0.0', true],
+            ['1.0.1', '<=1.0.0', false],
+            ['0.9.0', '<1.0.0', true],
+            ['1.0.0', '<1.0.0', false],
+
+            // exact
+            ['1.0.0', '=1.0.0', true],
+            ['1.0.0', '1.0.0', true],
+            ['1.0.1', '1.0.0', false],
+            ['1.0.0', '!=1.0.0', false],
+            ['1.0.1', '!=1.0.0', true],
+
+            // caret: ^1.2 → >=1.2 <2.0
+            ['1.2.0', '^1.2', true],
+            ['1.9.9', '^1.2', true],
+            ['2.0.0', '^1.2', false],
+            ['1.1.0', '^1.2', false],
+
+            // tilde: ~1.2.3 → >=1.2.3 <1.3.0
+            ['1.2.3', '~1.2.3', true],
+            ['1.2.9', '~1.2.3', true],
+            ['1.3.0', '~1.2.3', false],
+            ['1.2.2', '~1.2.3', false],
+
+            // leading v is tolerated on both sides
+            ['v1.5.0', '>=v1.2', true],
+        ];
+    }
+}

--- a/tests/Unit/Plugins/fixtures/plugins/broken/manifest.php
+++ b/tests/Unit/Plugins/fixtures/plugins/broken/manifest.php
@@ -1,0 +1,7 @@
+<?php
+
+// Invalid on purpose: missing the required 'name' and 'version' fields.
+// fromDirectory() must record this as skipped, not fatal.
+return [
+    'id' => 'broken',
+];

--- a/tests/Unit/Plugins/fixtures/plugins/good/manifest.php
+++ b/tests/Unit/Plugins/fixtures/plugins/good/manifest.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'id' => 'good',
+    'name' => 'Good Plugin',
+    'version' => '1.0.0',
+    'requires' => ['ignis' => '>=1.0'],
+    'default_enabled' => true,
+];


### PR DESCRIPTION
First piece of the plugin system from the design in #301: the foundation that discovers plugins and decides which are active, without touching the boot path yet. With no plugins on disk, the app behaves exactly as before.

## What's here

- **`PluginManifest`** — typed, validated view of a plugin's `manifest.php`: id, name, version, ignis compatibility range, dependencies, permissions, `default_enabled` / `removable`.
- **`VersionConstraint`** — a small semver matcher (`>=`, `<`, `^`, `~`, space-separated ranges) so a manifest can say `requires: ['ignis' => '>=1.2 <2.0']`. No new Composer dependency.
- **`PluginRegistry`** — discovers `plugins/<id>/manifest.php` and resolves the active set: enabled ∩ version-compatible ∩ dependencies satisfied, returned in dependency order. Anything that doesn't qualify is **skipped with a readable reason** rather than breaking the boot.
- **`PluginRepository` + `intra_plugins` migration** — persists installed/enabled state; a freshly discovered plugin is seeded from its `default_enabled` flag, so bundled first-party plugins are on by default without manual steps.

## Tests

Unit tests cover manifest validation, version matching across all operators, dependency ordering, cascade removal when a dependency drops out, cycle detection, and directory discovery (including skipping a broken manifest).

## Not in this PR

Wiring the registry into the bootstrap (routes, navigation, events, migrations, …) comes next, once this foundation is reviewed. The four modules being turned into plugins — eNOTF, fireTab, MANV-Board, Wissensdatenbank — follow after that, one at a time.
