### PR TITLE
Plugin system: wire plugins into the registers

### DIFF
--- a/assets/components/navbar-sidebar.php
+++ b/assets/components/navbar-sidebar.php
@@ -15,6 +15,13 @@ use App\Auth\Permissions;
 
 $navigationConfig = require __DIR__ . '/../../config/navigation.php';
 
+// Navigations-Einträge aktiver Plugins anhängen.
+try {
+    $navigationConfig = app(\App\Plugins\PluginLoader::class)->mergeNavigation($navigationConfig);
+} catch (\Throwable $e) {
+    \App\Logging\Logger::warning('Plugin-Navigation nicht geladen: ' . $e->getMessage());
+}
+
 /**
  * Filtert Rail/Sections/Items rekursiv nach Permissions.
  * Entfernt leere Sections/Rails, wenn nichts mehr sichtbar ist.

--- a/config/container.php
+++ b/config/container.php
@@ -159,6 +159,9 @@ return [
     \App\Http\Pipeline::class => \DI\autowire(),
     \App\Http\Router::class   => \DI\autowire(),
 
+    // Plugin-Loader — einmal pro Request, cached das aktive Plugin-Set.
+    \App\Plugins\PluginLoader::class => \DI\autowire(),
+
     // Stateless Middlewares ohne Parameter — als Singletons registriert,
     // damit sie per Pipeline-Shortstring ("FQCN") aufgelöst werden können.
     \App\Http\Middleware\ApiKeyMiddleware::class       => \DI\autowire(),
@@ -285,8 +288,14 @@ return [
 
         // Listener aus config/events.php laden und beim Illuminate-Dispatcher
         // registrieren. Jeder Listener wird lazy aus dem Container resolved,
-        // damit Constructor-Injection funktioniert.
+        // damit Constructor-Injection funktioniert. Aktive Plugins hängen
+        // ihre eigenen Listener über events.php-Fragmente an.
         $eventMap = require __DIR__ . '/events.php';
+        try {
+            $eventMap = $c->get(\App\Plugins\PluginLoader::class)->mergeEventMap($eventMap);
+        } catch (\Throwable $e) {
+            \App\Logging\Logger::warning('Plugin-Events nicht geladen: ' . $e->getMessage());
+        }
         foreach ($eventMap as $eventClass => $listenerClasses) {
             foreach ($listenerClasses as $listenerClass) {
                 $illuminate->listen($eventClass, function ($event) use ($c, $listenerClass): void {

--- a/phinx.php
+++ b/phinx.php
@@ -36,7 +36,14 @@ $env = static function (string $key, ?string $default = null): ?string {
 
 return [
     'paths' => [
-        'migrations' => __DIR__ . '/database/migrations',
+        // Kern-Migrations plus die Migrations-Verzeichnisse aller
+        // installierten Plugins. Bewusst alle (nicht nur aktive): ein
+        // deaktiviertes Plugin behält sein Schema, und diese Datei muss
+        // auch ohne App-Bootstrap in der CLI funktionieren.
+        'migrations' => array_merge(
+            [__DIR__ . '/database/migrations'],
+            glob(__DIR__ . '/plugins/*/migrations', GLOB_ONLYDIR) ?: [],
+        ),
         'seeds'      => __DIR__ . '/database/seeds',
     ],
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -13,16 +13,25 @@ Cores.
 ```
 plugins/<id>/
   manifest.php        Pflicht: Metadaten, Kompatibilität, Abhängigkeiten
-  routes.web.php      optional: web-Routen (bekommt $router)
+  routes.web.php      optional: web-Routen (bekommt $router, lädt nach den Kern-Routen)
   routes.api.php      optional: API-Routen
-  navigation.php      optional: Nav-Fragment (rail/sections)
-  events.php          optional: Event → Listener-Map
-  console.php         optional: Console-Command-Klassen
-  cron.php            optional: Cron-Job-Definitionen
-  migrations/         optional: eigene Phinx-Migrations (Prefix plugin_<id>_*)
+  navigation.php      optional: Liste von Rail-Einträgen (Format wie config/navigation.php)
+  events.php          optional: Event → Listener-Map (wird an die Kern-Map angehängt)
+  console.php         optional: Liste von Console-Command-Klassen
+  permissions.php     optional: Permission-Katalog (Gruppen-Format wie config/permissions.php)
+  migrations/         optional: eigene Phinx-Migrations (Tabellen-Prefix plugin_<id>_*)
   templates/          optional: Views
   src/                optional: Controller, Services (autowired)
 ```
+
+Die Fragmente aktiver Plugins werden beim Boot vom `PluginLoader` in die
+jeweiligen Register gemergt. Zwei Besonderheiten:
+
+- **Migrations laufen immer** — auch für deaktivierte Plugins. Deaktivieren
+  entfernt Routen/Nav/Listener, lässt Tabellen und Daten aber unangetastet,
+  damit beim Reaktivieren nichts fehlt.
+- **Plugin-Routen können Kern-Routen nicht überschreiben**, sie werden nach
+  den Kern-Routen registriert.
 
 Das Manifest ist die einzige Pflichtdatei:
 

--- a/public/index.php
+++ b/public/index.php
@@ -43,6 +43,17 @@ foreach ($routeFiles as $file) {
     }
 }
 
+// Routen aktiver Plugins registrieren — nach den Kern-Routen, damit ein
+// Plugin niemals eine Kern-Route shadowen kann. Jedes Fragment bekommt
+// dasselbe $router wie die Kern-Route-Dateien.
+try {
+    foreach (app(\App\Plugins\PluginLoader::class)->routeFiles() as $file) {
+        require $file;
+    }
+} catch (\Throwable $e) {
+    \App\Logging\Logger::warning('Plugin-Routen nicht geladen: ' . $e->getMessage());
+}
+
 // Eingehende Requests mit `.php`-Suffix → clean URL.
 // GET/HEAD bekommen einen 301, damit Browser-/Suchmaschinen-Cache
 // aufräumt; non-idempotente Methoden werden intern umgeschrieben,

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -31,6 +31,13 @@ final class Application extends SymfonyApplication
     {
         $commands = require __DIR__ . '/../../config/console.php';
 
+        // Commands aktiver Plugins anhängen.
+        try {
+            $commands = $this->container->get(\App\Plugins\PluginLoader::class)->mergeConsoleCommands($commands);
+        } catch (\Throwable $e) {
+            \App\Logging\Logger::warning('Plugin-Commands nicht geladen: ' . $e->getMessage());
+        }
+
         foreach ($commands as $commandClass) {
             /** @var Command $command */
             $command = $this->container->get($commandClass);

--- a/src/Database/AutoMigrator.php
+++ b/src/Database/AutoMigrator.php
@@ -24,11 +24,18 @@ class AutoMigrator
     private string $cacheFile;
     private string $migrationsPath;
 
+    /** @var list<string> zusätzliche Migrations-Verzeichnisse (Plugins) */
+    private array $extraMigrationPaths = [];
+
     public function __construct(PDO $pdo)
     {
         $this->pdo            = $pdo;
         $this->appRoot        = dirname(__DIR__, 2);
         $this->migrationsPath = $this->appRoot . '/database/migrations';
+        // Plugin-Migrations laufen unabhängig vom Aktiv-Status mit — ein
+        // deaktiviertes Plugin behält sein Schema, damit beim Reaktivieren
+        // nichts fehlt. phinx.php kennt dieselben Pfade.
+        $this->extraMigrationPaths = \App\Plugins\PluginLoader::migrationPaths();
 
         $logDir = $this->appRoot . '/storage/logs';
         if (!is_dir($logDir)) @mkdir($logDir, 0755, true);
@@ -43,6 +50,9 @@ class AutoMigrator
     public function runIfNeeded(): void
     {
         $files = glob($this->migrationsPath . '/*.php') ?: [];
+        foreach ($this->extraMigrationPaths as $dir) {
+            $files = array_merge($files, glob($dir . '/*.php') ?: []);
+        }
         if (count($files) === 0) {
             return;
         }

--- a/src/Http/Controllers/RoleController.php
+++ b/src/Http/Controllers/RoleController.php
@@ -38,6 +38,14 @@ class RoleController extends Controller
         $roles            = Role::query()->orderBy('priority')->get();
         $permissionGroups = require dirname(__DIR__, 3) . '/config/permissions.php';
 
+        // Permissions aktiver Plugins in den Katalog aufnehmen, damit sie
+        // in der Rollen-Verwaltung zuweisbar sind.
+        try {
+            $permissionGroups = app(\App\Plugins\PluginLoader::class)->mergePermissionGroups($permissionGroups);
+        } catch (\Throwable $e) {
+            \App\Logging\Logger::warning('Plugin-Permissions nicht geladen: ' . $e->getMessage());
+        }
+
         $this->renderView('roles/index', [
             'roles'            => $roles,
             'permissionGroups' => $permissionGroups,

--- a/src/Plugins/PluginLoader.php
+++ b/src/Plugins/PluginLoader.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plugins;
+
+use App\Logging\Logger;
+use PDO;
+
+/**
+ * Verbindet die entdeckten Plugins mit den Registern der Anwendung.
+ *
+ * Der Loader wird einmal pro Request aus dem Container aufgelöst und
+ * cached das aktive Plugin-Set. Die Call-Sites (Front-Controller,
+ * Navigation, Event-Dispatcher, Console) holen sich hier die Fragmente
+ * der aktiven Plugins und mergen sie in ihre jeweilige Struktur.
+ *
+ * Fehlertoleranz ist Pflicht: Wenn die Plugin-Tabelle (noch) nicht
+ * existiert — etwa bei einer frischen Installation vor dem ersten
+ * Migrationslauf — verhält sich die Anwendung, als gäbe es keine
+ * Plugins, statt den Boot zu brechen.
+ */
+class PluginLoader
+{
+    /** @var list<Plugin>|null */
+    private ?array $active = null;
+
+    public function __construct(
+        private readonly PDO $pdo,
+    ) {}
+
+    public static function pluginsDir(): string
+    {
+        return dirname(__DIR__, 2) . '/plugins';
+    }
+
+    /**
+     * Migrations-Verzeichnisse ALLER installierten Plugins — bewusst ohne
+     * Blick in die Datenbank. Schema-Migrationen laufen auch für
+     * deaktivierte Plugins, damit Deaktivieren nie Daten oder Schema
+     * zurücklässt, das beim Reaktivieren fehlt. Außerdem wird diese Liste
+     * von phinx.php gebraucht, das auch ohne App-Bootstrap (CLI) läuft.
+     *
+     * @return list<string>
+     */
+    public static function migrationPaths(): array
+    {
+        $dirs = glob(self::pluginsDir() . '/*/migrations', GLOB_ONLYDIR) ?: [];
+        sort($dirs);
+        return array_values($dirs);
+    }
+
+    /**
+     * Aktive Plugins in Ladereihenfolge (Abhängigkeiten zuerst).
+     *
+     * @return list<Plugin>
+     */
+    public function active(): array
+    {
+        if ($this->active !== null) {
+            return $this->active;
+        }
+
+        try {
+            $registry = PluginRegistry::fromDirectory(self::pluginsDir());
+            if ($registry->all() === []) {
+                return $this->active = [];
+            }
+
+            $repository = new PluginRepository($this->pdo);
+            $repository->syncDiscovered($registry->all());
+            $registry->resolve($repository->enabledIds(), self::ignisVersion());
+
+            foreach ($registry->skipped() as $skip) {
+                Logger::warning("Plugin '{$skip['id']}' übersprungen: {$skip['reason']}");
+            }
+
+            return $this->active = $registry->active();
+        } catch (\Throwable $e) {
+            // z.B. intra_plugins existiert noch nicht — Boot geht ohne
+            // Plugins weiter, die nächste Anfrage nach den Migrationen
+            // lädt sie dann normal.
+            Logger::warning('Plugins konnten nicht geladen werden: ' . $e->getMessage());
+            return $this->active = [];
+        }
+    }
+
+    /**
+     * Routen-Fragmente der aktiven Plugins (web zuerst, dann api —
+     * gleiche Reihenfolge wie die Kern-Routen).
+     *
+     * @return list<string>
+     */
+    public function routeFiles(): array
+    {
+        $files = [];
+        foreach (['routes.web.php', 'routes.api.php'] as $fragment) {
+            foreach ($this->active() as $plugin) {
+                $file = $plugin->path($fragment);
+                if ($file !== null) {
+                    $files[] = $file;
+                }
+            }
+        }
+        return $files;
+    }
+
+    /**
+     * Hängt die Navigations-Einträge der aktiven Plugins an die Rail an.
+     * Ein Plugin liefert in navigation.php eine Liste von Rail-Einträgen
+     * im selben Format wie config/navigation.php.
+     *
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    public function mergeNavigation(array $config): array
+    {
+        $rail = is_array($config['rail'] ?? null) ? $config['rail'] : [];
+
+        foreach ($this->active() as $plugin) {
+            $file = $plugin->path('navigation.php');
+            if ($file === null) {
+                continue;
+            }
+            $fragment = require $file;
+            if (is_array($fragment)) {
+                foreach ($fragment as $entry) {
+                    if (is_array($entry)) {
+                        $rail[] = $entry;
+                    }
+                }
+            }
+        }
+
+        $config['rail'] = $rail;
+        return $config;
+    }
+
+    /**
+     * Mergt die Event→Listener-Maps der aktiven Plugins in die Kern-Map.
+     * Listener desselben Events werden angehängt, nie ersetzt.
+     *
+     * @param array<string, list<string>> $eventMap Event-FQCN => Listener-FQCNs
+     * @return array<string, list<string>>
+     */
+    public function mergeEventMap(array $eventMap): array
+    {
+        foreach ($this->active() as $plugin) {
+            $file = $plugin->path('events.php');
+            if ($file === null) {
+                continue;
+            }
+            $fragment = require $file;
+            if (!is_array($fragment)) {
+                continue;
+            }
+            foreach ($fragment as $eventClass => $listeners) {
+                foreach ((array) $listeners as $listener) {
+                    $eventMap[$eventClass][] = $listener;
+                }
+            }
+        }
+        return $eventMap;
+    }
+
+    /**
+     * Hängt die Console-Commands der aktiven Plugins an die Kern-Liste an.
+     *
+     * @param list<string> $commands Command-FQCNs
+     * @return list<string>
+     */
+    public function mergeConsoleCommands(array $commands): array
+    {
+        foreach ($this->active() as $plugin) {
+            $file = $plugin->path('console.php');
+            if ($file === null) {
+                continue;
+            }
+            $fragment = require $file;
+            if (is_array($fragment)) {
+                foreach ($fragment as $commandClass) {
+                    if (is_string($commandClass)) {
+                        $commands[] = $commandClass;
+                    }
+                }
+            }
+        }
+        return $commands;
+    }
+
+    /**
+     * Mergt die Permission-Kataloge der aktiven Plugins (permissions.php,
+     * gleiche Gruppen-Struktur wie config/permissions.php) in den
+     * Kern-Katalog. Gleichnamige Gruppen werden zusammengeführt.
+     *
+     * @param array<string, array<string, string>> $groups
+     * @return array<string, array<string, string>>
+     */
+    public function mergePermissionGroups(array $groups): array
+    {
+        foreach ($this->active() as $plugin) {
+            $file = $plugin->path('permissions.php');
+            if ($file === null) {
+                continue;
+            }
+            $fragment = require $file;
+            if (!is_array($fragment)) {
+                continue;
+            }
+            foreach ($fragment as $group => $permissions) {
+                if (!is_array($permissions)) {
+                    continue;
+                }
+                $groups[$group] = array_merge($groups[$group] ?? [], $permissions);
+            }
+        }
+        return $groups;
+    }
+
+    /**
+     * Laufende ignis-Version aus storage/version.json; null in
+     * Entwicklungs-Checkouts ohne Release-Build (dann gelten alle
+     * Plugins als kompatibel).
+     */
+    private static function ignisVersion(): ?string
+    {
+        $file = dirname(__DIR__, 2) . '/storage/version.json';
+        if (!is_file($file)) {
+            return null;
+        }
+        $data = json_decode((string) file_get_contents($file), true);
+        return is_array($data) && !empty($data['version']) ? (string) $data['version'] : null;
+    }
+}

--- a/src/Plugins/PluginRegistry.php
+++ b/src/Plugins/PluginRegistry.php
@@ -69,12 +69,13 @@ final class PluginRegistry
 
     /**
      * Berechnet das aktive Set für die gegebenen aktivierten IDs und die
-     * laufende ignis-Version. Idempotent — kann erneut mit anderem Set
-     * aufgerufen werden.
+     * laufende ignis-Version. Ohne bekannte Version (Entwicklungs-Checkout
+     * ohne Release-Build) entfällt die Kompatibilitätsprüfung. Idempotent —
+     * kann erneut mit anderem Set aufgerufen werden.
      *
      * @param list<string> $enabledIds
      */
-    public function resolve(array $enabledIds, string $ignisVersion): void
+    public function resolve(array $enabledIds, ?string $ignisVersion): void
     {
         $this->active = [];
         $enabled = array_fill_keys($enabledIds, true);
@@ -85,7 +86,7 @@ final class PluginRegistry
             if (!isset($enabled[$id])) {
                 continue; // deaktiviert — kein Skip-Grund, bewusst aus
             }
-            if (!$plugin->manifest->isCompatibleWith($ignisVersion)) {
+            if ($ignisVersion !== null && !$plugin->manifest->isCompatibleWith($ignisVersion)) {
                 $this->skipped[] = [
                     'id' => $id,
                     'reason' => "Benötigt ignis {$plugin->manifest->ignisRequire}, läuft auf {$ignisVersion}.",

--- a/tests/Unit/Plugins/PluginLoaderTest.php
+++ b/tests/Unit/Plugins/PluginLoaderTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Plugins;
+
+use App\Plugins\Plugin;
+use App\Plugins\PluginLoader;
+use App\Plugins\PluginManifest;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testet die Merge-Logik des Loaders gegen das Fixture-Plugin „good".
+ * Das aktive Set wird gestubbt, damit kein Datenbank-Zugriff nötig ist —
+ * die Auflösung selbst deckt PluginRegistryTest ab.
+ */
+class PluginLoaderTest extends TestCase
+{
+    /**
+     * @param list<Plugin> $plugins
+     */
+    private function loaderWith(array $plugins): PluginLoader
+    {
+        return new class($plugins) extends PluginLoader {
+            /** @param list<Plugin> $stubbed */
+            public function __construct(private readonly array $stubbed)
+            {
+                // PDO wird nicht gebraucht — active() ist gestubbt.
+            }
+
+            public function active(): array
+            {
+                return $this->stubbed;
+            }
+        };
+    }
+
+    private function goodPlugin(): Plugin
+    {
+        $dir = __DIR__ . '/fixtures/plugins/good';
+        $manifest = PluginManifest::fromArray(require $dir . '/manifest.php');
+        return new Plugin($manifest, $dir);
+    }
+
+    #[Test]
+    public function it_appends_plugin_navigation_to_the_rail(): void
+    {
+        $loader = $this->loaderWith([$this->goodPlugin()]);
+
+        $config = ['rail' => [['id' => 'core', 'label' => 'Core']]];
+        $merged = $loader->mergeNavigation($config);
+
+        $this->assertCount(2, $merged['rail']);
+        $this->assertSame('core', $merged['rail'][0]['id']);
+        $this->assertSame('good', $merged['rail'][1]['id']);
+    }
+
+    #[Test]
+    public function it_merges_event_listeners_without_replacing_core_ones(): void
+    {
+        $loader = $this->loaderWith([$this->goodPlugin()]);
+
+        $map = ['App\\Events\\SomethingHappened' => ['Core\\Listener']];
+        $merged = $loader->mergeEventMap($map);
+
+        $this->assertSame(
+            ['Core\\Listener', 'GoodPlugin\\Listeners\\OnSomething'],
+            $merged['App\\Events\\SomethingHappened']
+        );
+    }
+
+    #[Test]
+    public function it_appends_console_commands(): void
+    {
+        $loader = $this->loaderWith([$this->goodPlugin()]);
+
+        $merged = $loader->mergeConsoleCommands(['Core\\Command']);
+
+        $this->assertSame(['Core\\Command', 'GoodPlugin\\Console\\SyncCommand'], $merged);
+    }
+
+    #[Test]
+    public function it_merges_permission_groups_by_name(): void
+    {
+        $loader = $this->loaderWith([$this->goodPlugin()]);
+
+        $groups = ['Protokolle' => ['core.view' => 'Kern ansehen']];
+        $merged = $loader->mergePermissionGroups($groups);
+
+        $this->assertArrayHasKey('Good Plugin', $merged);
+        $this->assertSame('Good Plugin ansehen', $merged['Good Plugin']['good.view']);
+        // gleichnamige Gruppe wird zusammengeführt, nicht ersetzt
+        $this->assertSame('Kern ansehen', $merged['Protokolle']['core.view']);
+        $this->assertSame('Good-Einträge im Protokoll sehen', $merged['Protokolle']['good.audit']);
+    }
+
+    #[Test]
+    public function it_lists_existing_route_fragments_only(): void
+    {
+        $loader = $this->loaderWith([$this->goodPlugin()]);
+
+        $files = $loader->routeFiles();
+
+        $this->assertCount(1, $files);
+        $this->assertStringEndsWith('routes.web.php', $files[0]);
+    }
+
+    #[Test]
+    public function plugins_without_fragments_contribute_nothing(): void
+    {
+        // Manifest-only Plugin: kein navigation.php, events.php, …
+        $bare = new Plugin(
+            PluginManifest::fromArray(['id' => 'bare', 'name' => 'Bare', 'version' => '1.0.0']),
+            sys_get_temp_dir()
+        );
+        $loader = $this->loaderWith([$bare]);
+
+        $this->assertSame(['rail' => []], $loader->mergeNavigation(['rail' => []]));
+        $this->assertSame([], $loader->mergeEventMap([]));
+        $this->assertSame([], $loader->mergeConsoleCommands([]));
+        $this->assertSame([], $loader->mergePermissionGroups([]));
+        $this->assertSame([], $loader->routeFiles());
+    }
+}

--- a/tests/Unit/Plugins/PluginRegistryTest.php
+++ b/tests/Unit/Plugins/PluginRegistryTest.php
@@ -79,6 +79,19 @@ class PluginRegistryTest extends TestCase
     }
 
     #[Test]
+    public function it_treats_an_unknown_ignis_version_as_compatible(): void
+    {
+        $registry = new PluginRegistry($this->keyed([
+            $this->plugin('enotf', [], '>=2.0'),
+        ]));
+
+        $registry->resolve(['enotf'], null);
+
+        $this->assertSame(['enotf'], $this->ids($registry->active()));
+        $this->assertSame([], $registry->skipped());
+    }
+
+    #[Test]
     public function it_skips_version_incompatible_plugins(): void
     {
         $registry = new PluginRegistry($this->keyed([

--- a/tests/Unit/Plugins/fixtures/plugins/good/console.php
+++ b/tests/Unit/Plugins/fixtures/plugins/good/console.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'GoodPlugin\\Console\\SyncCommand',
+];

--- a/tests/Unit/Plugins/fixtures/plugins/good/events.php
+++ b/tests/Unit/Plugins/fixtures/plugins/good/events.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'App\\Events\\SomethingHappened' => [
+        'GoodPlugin\\Listeners\\OnSomething',
+    ],
+];

--- a/tests/Unit/Plugins/fixtures/plugins/good/navigation.php
+++ b/tests/Unit/Plugins/fixtures/plugins/good/navigation.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    [
+        'id' => 'good',
+        'label' => 'Good Plugin',
+        'icon' => 'fa-solid fa-puzzle-piece',
+        'href' => '/good',
+    ],
+];

--- a/tests/Unit/Plugins/fixtures/plugins/good/permissions.php
+++ b/tests/Unit/Plugins/fixtures/plugins/good/permissions.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'Good Plugin' => [
+        'good.view' => 'Good Plugin ansehen',
+    ],
+    'Protokolle' => [
+        'good.audit' => 'Good-Einträge im Protokoll sehen',
+    ],
+];

--- a/tests/Unit/Plugins/fixtures/plugins/good/routes.web.php
+++ b/tests/Unit/Plugins/fixtures/plugins/good/routes.web.php
@@ -1,0 +1,4 @@
+<?php
+
+// Nur für Tests: markiert, dass die Datei geladen wurde.
+$GLOBALS['__good_plugin_routes_loaded'] = true;


### PR DESCRIPTION
Second building block after #302: the `PluginLoader` resolves the active plugin set once per request and merges plugin fragments into the existing registers - routes (after core, no shadowing), navigation rail, event listener map, console commands, permission catalog, and migrations (AutoMigrator + phinx.php include `plugins/*/migrations` for all installed plugins, independent of the enabled flag, so disabling never orphans schema).

Every call-site degrades gracefully: if plugins cannot be resolved (fresh install before the `intra_plugins` migration, missing PDO in an odd context), the app boots core-only and logs a warning. With an empty `plugins/` directory, behaviour is byte-identical to before.

Unit tests cover the merge logic against a fixture plugin (navigation, events, console, permissions, route fragments, and the nothing-contributed case); resolution logic itself was covered in #302. The existing Feature suite exercises the wired boot path end-to-end.