### PR TITLE
Plugin system: autoloading, plugin views, policy registry

### DIFF
--- a/assets/config/config.php
+++ b/assets/config/config.php
@@ -81,6 +81,18 @@ try {
     \App\Logging\Logger::warning("Auto-migration check failed: " . $e->getMessage());
 }
 
+// Aktive Plugins anbinden: Autoloading für ihre Klassen und Gate-Policies
+// registrieren. Muss vor dem Routing laufen, weil Plugin-Controller sonst
+// beim Dispatch nicht auflösbar wären. Schlägt fehl-tolerant fehl — ohne
+// ladbare Plugins läuft der Kern normal weiter.
+try {
+    $pluginLoader = $GLOBALS['app_container']->get(\App\Plugins\PluginLoader::class);
+    $pluginLoader->registerAutoloading();
+    $pluginLoader->registerPolicies();
+} catch (\Throwable $e) {
+    \App\Logging\Logger::warning('Plugin-Bootstrap fehlgeschlagen: ' . $e->getMessage());
+}
+
 try {
     $configManager = new ConfigManager($pdo);
     $configManager->loadAndDefineConfig();

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -46,7 +46,15 @@ return [
     'requires'        => ['ignis' => '>=1.2 <2.0'],
     'depends'         => [],
     'permissions'     => ['enotf.view', 'enotf.edit', 'enotf.admin'],
+    // PSR-4-Autoloading für die Plugin-Klassen (Prefix => Ordner im Plugin)
+    'autoload'        => ['Plugin\\Enotf\\' => 'src/'],
+    // Gate-Policies: Ressource => Policy-Klasse
+    'policies'        => ['enotf' => 'Plugin\\Enotf\\Policies\\EnotfPolicy'],
     'default_enabled' => true,
     'removable'       => true,
 ];
 ```
+
+Controller in Plugins erben von `App\Http\Controllers\Controller` und
+überschreiben `viewBasePath()`, damit `renderView()` die Views aus dem
+eigenen `templates/`-Verzeichnis lädt.

--- a/src/Auth/Gate.php
+++ b/src/Auth/Gate.php
@@ -66,6 +66,23 @@ class Gate
     }
 
     /**
+     * Explizit registrierte Policies (Ressource => Policy-Klasse).
+     * Ergänzt die Namespace-Konvention — Plugins registrieren ihre
+     * Policies hierüber, weil sie außerhalb von App\Policies leben.
+     *
+     * @var array<string, class-string>
+     */
+    private static array $registered = [];
+
+    /**
+     * @param class-string $policyClass
+     */
+    public static function registerPolicy(string $resource, string $policyClass): void
+    {
+        self::$registered[strtolower($resource)] = $policyClass;
+    }
+
+    /**
      * @return array{0: class-string|null, 1: string}
      */
     private static function resolve(string $ability): array
@@ -74,7 +91,9 @@ class Gate
             return [null, ''];
         }
         [$resource, $method] = explode('.', $ability, 2);
-        $policyClass = '\\App\\Policies\\' . ucfirst($resource) . 'Policy';
+
+        $policyClass = self::$registered[strtolower($resource)]
+            ?? '\\App\\Policies\\' . ucfirst($resource) . 'Policy';
 
         if (!class_exists($policyClass)) {
             return [null, $method];

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -81,11 +81,24 @@ abstract class Controller
      * (navbar.php, global-announcements.php, footer.php, ...) die Variable
      * als lokale Referenz erwarten.
      *
+     * Views werden relativ zu viewBasePath() aufgelöst — Controller in
+     * Plugins überschreiben die Methode und zeigen auf ihr eigenes
+     * templates/-Verzeichnis.
+     *
      * @param array<string,mixed> $data
      */
+    /**
+     * Basis-Verzeichnis für renderView(). Plugin-Controller überschreiben
+     * das und liefern das templates/-Verzeichnis ihres Plugins.
+     */
+    protected function viewBasePath(): string
+    {
+        return dirname(__DIR__, 3) . '/templates';
+    }
+
     protected function renderView(string $view, array $data = []): void
     {
-        $templatePath = dirname(__DIR__, 3) . '/templates/' . $view . '.php';
+        $templatePath = rtrim($this->viewBasePath(), '/\\') . '/' . $view . '.php';
         if (!is_file($templatePath)) {
             throw new \RuntimeException("View not found: $view ($templatePath)");
         }

--- a/src/Plugins/PluginLoader.php
+++ b/src/Plugins/PluginLoader.php
@@ -86,6 +86,58 @@ class PluginLoader
     }
 
     /**
+     * Ist ein bestimmtes Plugin installiert UND aktiv? Für Kern-Code, der
+     * modulübergreifende Inhalte nur anbieten soll, wenn das Modul läuft
+     * (z.B. Suchergebnisse eines abgeschalteten Moduls unterdrücken).
+     */
+    public function isActive(string $pluginId): bool
+    {
+        foreach ($this->active() as $plugin) {
+            if ($plugin->id() === $pluginId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Registriert die PSR-4-Autoload-Maps der aktiven Plugins. Muss im
+     * Bootstrap laufen, bevor Plugin-Klassen (Controller, Listener,
+     * Policies) referenziert werden.
+     */
+    public function registerAutoloading(): void
+    {
+        foreach ($this->active() as $plugin) {
+            foreach ($plugin->manifest->autoload as $prefix => $relativeDir) {
+                $baseDir = $plugin->directory . DIRECTORY_SEPARATOR . trim($relativeDir, '/\\');
+                spl_autoload_register(static function (string $class) use ($prefix, $baseDir): void {
+                    if (!str_starts_with($class, $prefix)) {
+                        return;
+                    }
+                    $relative = substr($class, strlen($prefix));
+                    $file = $baseDir . DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $relative) . '.php';
+                    if (is_file($file)) {
+                        require $file;
+                    }
+                });
+            }
+        }
+    }
+
+    /**
+     * Registriert die Gate-Policies der aktiven Plugins (Manifest-Feld
+     * `policies`: Ressource => Policy-FQCN).
+     */
+    public function registerPolicies(): void
+    {
+        foreach ($this->active() as $plugin) {
+            foreach ($plugin->manifest->policies as $resource => $policyClass) {
+                \App\Auth\Gate::registerPolicy($resource, $policyClass);
+            }
+        }
+    }
+
+    /**
      * Routen-Fragmente der aktiven Plugins (web zuerst, dann api —
      * gleiche Reihenfolge wie die Kern-Routen).
      *

--- a/src/Plugins/PluginManifest.php
+++ b/src/Plugins/PluginManifest.php
@@ -30,15 +30,17 @@ use InvalidArgumentException;
 final class PluginManifest
 {
     /**
-     * @param string        $id            Eindeutige, stabile Plugin-ID (kebab/snake, [a-z0-9_-])
-     * @param string        $name          Menschlich lesbarer Anzeigename
-     * @param string        $version       Semver-Version des Plugins
-     * @param string        $vendor        Herausgeber (z.B. "EmergencyForge")
-     * @param string        $ignisRequire  Kompatibilitätsbereich zur ignis-Version
-     * @param list<string>  $depends       IDs anderer Plugins, die aktiv sein müssen
-     * @param list<string>  $permissions   Permissions, die dieses Plugin einbringt
-     * @param bool          $defaultEnabled Bei Erstinstallation direkt aktiv?
-     * @param bool          $removable      Darf der Nutzer es deaktivieren?
+     * @param string                $id            Eindeutige, stabile Plugin-ID (kebab/snake, [a-z0-9_-])
+     * @param string                $name          Menschlich lesbarer Anzeigename
+     * @param string                $version       Semver-Version des Plugins
+     * @param string                $vendor        Herausgeber (z.B. "EmergencyForge")
+     * @param string                $ignisRequire  Kompatibilitätsbereich zur ignis-Version
+     * @param list<string>          $depends       IDs anderer Plugins, die aktiv sein müssen
+     * @param list<string>          $permissions   Permissions, die dieses Plugin einbringt
+     * @param array<string, string> $autoload      PSR-4-Map: Namespace-Prefix => Verzeichnis (relativ zum Plugin)
+     * @param array<string, string> $policies      Gate-Ressource => Policy-Klasse (FQCN)
+     * @param bool                  $defaultEnabled Bei Erstinstallation direkt aktiv?
+     * @param bool                  $removable      Darf der Nutzer es deaktivieren?
      */
     private function __construct(
         public readonly string $id,
@@ -48,6 +50,8 @@ final class PluginManifest
         public readonly string $ignisRequire,
         public readonly array $depends,
         public readonly array $permissions,
+        public readonly array $autoload,
+        public readonly array $policies,
         public readonly bool $defaultEnabled,
         public readonly bool $removable,
     ) {}
@@ -79,6 +83,8 @@ final class PluginManifest
             ignisRequire: isset($requires['ignis']) ? (string) $requires['ignis'] : '*',
             depends: self::stringList($data['depends'] ?? []),
             permissions: self::stringList($data['permissions'] ?? []),
+            autoload: self::stringMap($data['autoload'] ?? []),
+            policies: self::stringMap($data['policies'] ?? []),
             defaultEnabled: (bool) ($data['default_enabled'] ?? false),
             removable: (bool) ($data['removable'] ?? true),
         );
@@ -114,5 +120,23 @@ final class PluginManifest
             return [];
         }
         return array_values(array_map(static fn ($v): string => (string) $v, $value));
+    }
+
+    /**
+     * @param mixed $value
+     * @return array<string, string>
+     */
+    private static function stringMap(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $k => $v) {
+            if (is_string($k) && is_string($v) && $k !== '' && $v !== '') {
+                $out[$k] = $v;
+            }
+        }
+        return $out;
     }
 }

--- a/tests/Unit/Plugins/PluginLoaderTest.php
+++ b/tests/Unit/Plugins/PluginLoaderTest.php
@@ -107,6 +107,28 @@ class PluginLoaderTest extends TestCase
     }
 
     #[Test]
+    public function it_reports_active_plugins_by_id(): void
+    {
+        $loader = $this->loaderWith([$this->goodPlugin()]);
+
+        $this->assertTrue($loader->isActive('good'));
+        $this->assertFalse($loader->isActive('missing'));
+    }
+
+    #[Test]
+    public function it_autoloads_plugin_classes_and_registers_their_policies(): void
+    {
+        $loader = $this->loaderWith([$this->goodPlugin()]);
+
+        $loader->registerAutoloading();
+        $loader->registerPolicies();
+
+        $this->assertTrue(class_exists('GoodPluginFixture\\Policies\\GoodresPolicy'));
+        $this->assertTrue(\App\Auth\Gate::allows('goodres.view'));
+        $this->assertFalse(\App\Auth\Gate::allows('goodres.edit'));
+    }
+
+    #[Test]
     public function plugins_without_fragments_contribute_nothing(): void
     {
         // Manifest-only Plugin: kein navigation.php, events.php, …

--- a/tests/Unit/Plugins/fixtures/plugins/good/manifest.php
+++ b/tests/Unit/Plugins/fixtures/plugins/good/manifest.php
@@ -5,5 +5,7 @@ return [
     'name' => 'Good Plugin',
     'version' => '1.0.0',
     'requires' => ['ignis' => '>=1.0'],
+    'autoload' => ['GoodPluginFixture\\' => 'src/'],
+    'policies' => ['goodres' => 'GoodPluginFixture\\Policies\\GoodresPolicy'],
     'default_enabled' => true,
 ];

--- a/tests/Unit/Plugins/fixtures/plugins/good/src/Policies/GoodresPolicy.php
+++ b/tests/Unit/Plugins/fixtures/plugins/good/src/Policies/GoodresPolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GoodPluginFixture\Policies;
+
+/**
+ * Fixture-Policy für die Gate-Registrierung über das Plugin-Manifest.
+ */
+final class GoodresPolicy
+{
+    public static function view(mixed $resource = null): bool
+    {
+        return true;
+    }
+
+    public static function edit(mixed $resource = null): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Third building block, and the last one before actual module extraction. Plugins can now bring everything a real module consists of:

- **Classes**: the manifest declares a PSR-4 autoload map; the loader registers it at bootstrap, before routing can dispatch a plugin controller.
- **Views**: `Controller::renderView()` resolves against an overridable `viewBasePath()` instead of a hardcoded path, so plugin controllers render from their own `templates/` directory. Core controllers are untouched.
- **Policies**: `Gate` resolved policies purely by the `App\Policies` naming convention, which plugin classes cannot satisfy - it now consults an explicit registry first, fed from the manifest (`policies: resource => class`).
- `PluginLoader::isActive()` lets core code suppress cross-module content (e.g. global search results) for disabled plugins.

Unit tests drive all of it through the fixture plugin: the autoload map loads a real fixture class, its policy answers through `Gate::allows()`, and `isActive()` reports correctly.

Next up: extracting the Wissensdatenbank as the first real plugin on top of these pieces.