### PR TITLE
Deny direct web access to the plugins directory

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -55,6 +55,7 @@ RewriteRule ^config/ - [F,L]
 RewriteRule ^docker/ - [F,L]
 RewriteRule ^routes/ - [F,L]
 RewriteRule ^\.github/ - [F,L]
+RewriteRule ^plugins/ - [F,L]
 
 # cron/ bleibt erreichbar, weil HTTP-triggerbare Cron-Endpoints dort liegen
 # (queue-worker-cron.php, telemetry-cron.php). Diese prüfen API-Key intern

--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -77,8 +77,8 @@ server {
     }
 
     # Nicht-web-Verzeichnisse — synchron zur .htaccess-Blocklist
-    # (src, cli, tools, tests, database, config, docker, routes, .github)
-    location ~ ^/(src|cli|tools|tests|database|config|docker|routes|\.github)/ {
+    # (src, cli, tools, tests, database, config, docker, routes, plugins, .github)
+    location ~ ^/(src|cli|tools|tests|database|config|docker|routes|plugins|\.github)/ {
         return 403;
     }
 

--- a/plugins/.htaccess
+++ b/plugins/.htaccess
@@ -1,0 +1,15 @@
+# Plugins sind reiner Anwendungscode und werden ausschließlich über den
+# PluginLoader eingebunden — direkter HTTP-Zugriff würde Templates und
+# Migrations-Dateien ohne Bootstrap ausführen. Deshalb ist das gesamte
+# Verzeichnis für den Webserver gesperrt.
+#
+# Wenn Plugins später eigene statische Assets ausliefern (plugin.css,
+# plugin.js), bekommt deren assets/-Unterordner hier eine explizite
+# Ausnahme — bis dahin gilt: alles dicht.
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order allow,deny
+    Deny from all
+</IfModule>


### PR DESCRIPTION
Follow-up to #306. Plugin templates and migration bodies sat inside the webroot and were directly reachable over HTTP, where they would execute without the bootstrap. plugins/ now joins the existing directory blocklist (rewrite rule), gets its own deny-all .htaccess for setups without mod_rewrite, and the nginx example blocks it too. Everything a plugin does runs through the PluginLoader via the filesystem, so no legitimate access path is affected. When plugins later ship static assets, their assets/ subfolder gets an explicit exception.