### PR TITLE
Plugin management UI with an install gate for third-party plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ intrap
 .phpunit.cache/
 CLAUDE.md
 .impeccable.md
+# Installations-Marker manuell installierter Plugins (pro Instanz, nie committen)
+plugins/*/.installed

--- a/config/navigation.php
+++ b/config/navigation.php
@@ -355,6 +355,11 @@ return [
                             'permissions' => ['admin'],
                         ],
                         [
+                            'label'       => 'Plugins',
+                            'href'        => BASE_PATH . 'settings/system/plugins',
+                            'permissions' => ['admin'],
+                        ],
+                        [
                             'label'       => 'Telemetrie',
                             'href'        => BASE_PATH . 'settings/system/telemetry',
                             'permissions' => ['admin'],

--- a/phinx.php
+++ b/phinx.php
@@ -36,13 +36,17 @@ $env = static function (string $key, ?string $default = null): ?string {
 
 return [
     'paths' => [
-        // Kern-Migrations plus die Migrations-Verzeichnisse aller
-        // installierten Plugins. Bewusst alle (nicht nur aktive): ein
-        // deaktiviertes Plugin behält sein Schema, und diese Datei muss
-        // auch ohne App-Bootstrap in der CLI funktionieren.
+        // Kern-Migrations plus die Migrations-Verzeichnisse installierter
+        // Plugins. Installiert = mitgeliefert oder vom Admin bestätigt —
+        // ein bloß nach plugins/ kopiertes Fremd-Plugin migriert nichts.
+        // Deaktivierte (aber installierte) Plugins bleiben drin: ihr
+        // Schema gehört erhalten. Die Filterlogik lebt im PluginLoader
+        // und ist datenbankfrei, damit sie auch hier in der CLI läuft.
         'migrations' => array_merge(
             [__DIR__ . '/database/migrations'],
-            glob(__DIR__ . '/plugins/*/migrations', GLOB_ONLYDIR) ?: [],
+            class_exists(\App\Plugins\PluginLoader::class)
+                ? \App\Plugins\PluginLoader::migrationPaths()
+                : [],
         ),
         'seeds'      => __DIR__ . '/database/seeds',
     ],

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,13 +25,21 @@ plugins/<id>/
 ```
 
 Die Fragmente aktiver Plugins werden beim Boot vom `PluginLoader` in die
-jeweiligen Register gemergt. Zwei Besonderheiten:
+jeweiligen Register gemergt. Drei Besonderheiten:
 
-- **Migrations laufen immer** — auch für deaktivierte Plugins. Deaktivieren
-  entfernt Routen/Nav/Listener, lässt Tabellen und Daten aber unangetastet,
-  damit beim Reaktivieren nichts fehlt.
+- **Fremde Plugins sind erst nach ausdrücklicher Installation aktiv.** Nur
+  die offiziell mitgelieferten Plugins (Liste `PluginLoader::BUNDLED` im
+  Core) laufen ohne weiteres Zutun. Alles andere bleibt nach dem Ablegen in
+  `plugins/` vollständig inert — kein Code, keine Migration — bis ein Admin
+  die Installation in den Systemeinstellungen startet (schreibt die
+  Marker-Datei `.installed` in den Plugin-Ordner).
+- **Migrations installierter Plugins laufen immer** — auch für deaktivierte.
+  Deaktivieren entfernt Routen/Nav/Listener, lässt Tabellen und Daten aber
+  unangetastet, damit beim Reaktivieren nichts fehlt.
 - **Plugin-Routen können Kern-Routen nicht überschreiben**, sie werden nach
   den Kern-Routen registriert.
+
+Verwaltet werden Plugins unter **Einstellungen → System → Plugins**.
 
 Das Manifest ist die einzige Pflichtdatei:
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -581,6 +581,8 @@ $router->post('/settings/system/config',      [\App\Http\Controllers\Settings\Sy
 $router->get('/settings/system/performance', [\App\Http\Controllers\Settings\SystemController::class, 'performance'], $settingsAuth);
 $router->get('/settings/system/telemetry',      [\App\Http\Controllers\Settings\SystemController::class, 'telemetry'],   $settingsAuth);
 $router->post('/settings/system/telemetry',     [\App\Http\Controllers\Settings\SystemController::class, 'telemetry'],   $settingsAuth);
+$router->get('/settings/system/plugins',        [\App\Http\Controllers\Settings\PluginsController::class, 'index'],      $settingsAuth);
+$router->post('/settings/system/plugins',       [\App\Http\Controllers\Settings\PluginsController::class, 'index'],      $settingsAuth);
 $router->get('/settings/system/logs',     [\App\Http\Controllers\Settings\LogsController::class, 'index'], $settingsAuth);
 
 // Cron-Verwaltung

--- a/src/Http/Controllers/Settings/PluginsController.php
+++ b/src/Http/Controllers/Settings/PluginsController.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Auth\Gate;
+use App\Helpers\Flash;
+use App\Http\Controllers\Controller;
+use App\Plugins\PluginLoader;
+use App\Plugins\PluginRegistry;
+use App\Plugins\PluginRepository;
+use App\Security\CsrfProtection;
+
+/**
+ * Plugin-Verwaltung — Liste der installierten Plugins mit Aktiv-Schalter.
+ *
+ * Aktivieren prüft Kompatibilität und Abhängigkeiten, Deaktivieren
+ * respektiert das removable-Flag und blockt, solange ein anderes aktives
+ * Plugin das Modul braucht. Daten und Tabellen bleiben beim Deaktivieren
+ * unangetastet — nur Routen, Navigation und Listener verschwinden.
+ */
+final class PluginsController extends Controller
+{
+    /**
+     * GET/POST /settings/system/plugins
+     */
+    public function index(): void
+    {
+        $this->requireAuth();
+        if (!Gate::allows('system.admin')) {
+            Flash::set('error', 'no-permissions');
+            $this->redirect('index');
+        }
+
+        $registry   = PluginRegistry::fromDirectory(PluginLoader::pluginsDir());
+        $repository = new PluginRepository($this->pdo);
+        $repository->syncDiscovered($registry->all());
+
+        $message     = '';
+        $messageType = '';
+
+        if (($_SERVER['REQUEST_METHOD'] ?? '') === 'POST') {
+            if (!CsrfProtection::validateToken((string) ($_POST['csrf_token'] ?? ''))) {
+                $message     = 'Sitzung abgelaufen — bitte Seite neu laden und erneut versuchen.';
+                $messageType = 'danger';
+            } elseif (($_POST['plugin_action'] ?? '') === 'install') {
+                [$message, $messageType] = $this->handleInstall(
+                    (string) ($_POST['plugin_id'] ?? ''),
+                    $registry,
+                    $repository,
+                );
+            } else {
+                [$message, $messageType] = $this->handleToggle(
+                    (string) ($_POST['plugin_id'] ?? ''),
+                    $registry,
+                    $repository,
+                );
+            }
+        }
+
+        // Aktueller Zustand nach eventueller Änderung
+        $enabledIds = $repository->enabledIds();
+        $registry->resolve($enabledIds, null);
+
+        $activeIds = [];
+        foreach ($registry->active() as $plugin) {
+            $activeIds[$plugin->id()] = true;
+        }
+        $skipReasons = [];
+        foreach ($registry->skipped() as $skip) {
+            $skipReasons[$skip['id']] = $skip['reason'];
+        }
+
+        $rows = [];
+        foreach ($registry->all() as $id => $plugin) {
+            $rows[] = [
+                'id'         => $id,
+                'manifest'   => $plugin->manifest,
+                'installed'  => PluginLoader::isInstalled($plugin),
+                'bundled'    => PluginLoader::isBundled($id),
+                'enabled'    => in_array($id, $enabledIds, true),
+                'active'     => isset($activeIds[$id]),
+                'skipReason' => $skipReasons[$id] ?? null,
+                'requiredBy' => $this->enabledDependents($id, $registry, $enabledIds),
+            ];
+        }
+        usort($rows, static fn (array $a, array $b): int => strcasecmp($a['manifest']->name, $b['manifest']->name));
+
+        $this->renderView('settings/system/plugins', [
+            'rows'        => $rows,
+            'message'     => $message,
+            'messageType' => $messageType,
+        ]);
+    }
+
+    /**
+     * Startet die manuelle Installation eines nicht mitgelieferten Plugins:
+     * Marker schreiben, Migrationen anstoßen, aktivieren. Der Aufruf ist
+     * die bewusste Admin-Entscheidung, fremden Code auszuführen — vorher
+     * bleibt ein hochkopiertes Plugin vollständig inert.
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function handleInstall(string $pluginId, PluginRegistry $registry, PluginRepository $repository): array
+    {
+        $plugin = $registry->get($pluginId);
+        if ($plugin === null) {
+            return ['Unbekanntes Plugin.', 'danger'];
+        }
+        if (PluginLoader::isInstalled($plugin)) {
+            return ["„{$plugin->manifest->name}\u{201c} ist bereits installiert.", 'warning'];
+        }
+
+        if (!PluginLoader::markInstalled($plugin)) {
+            return ['Installations-Marker konnte nicht geschrieben werden — bitte Schreibrechte im Plugin-Verzeichnis prüfen.', 'danger'];
+        }
+
+        // Migrationen des frisch installierten Plugins direkt ausführen,
+        // statt auf den nächsten Request zu warten.
+        try {
+            (new \App\Database\AutoMigrator($this->pdo))->runIfNeeded();
+        } catch (\Throwable $e) {
+            return [
+                "„{$plugin->manifest->name}\u{201c} wurde installiert, aber der Migrationslauf meldete: " . $e->getMessage(),
+                'warning',
+            ];
+        }
+
+        $repository->setEnabled($pluginId, true);
+        return ["„{$plugin->manifest->name}\u{201c} wurde installiert und aktiviert.", 'success'];
+    }
+
+    /**
+     * Schaltet ein Plugin um und liefert [Meldung, Typ] für die Anzeige.
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function handleToggle(string $pluginId, PluginRegistry $registry, PluginRepository $repository): array
+    {
+        $plugin = $registry->get($pluginId);
+        if ($plugin === null) {
+            return ['Unbekanntes Plugin.', 'danger'];
+        }
+        if (!PluginLoader::isInstalled($plugin)) {
+            return ["„{$plugin->manifest->name}\u{201c} ist noch nicht installiert — bitte zuerst die Installation starten.", 'warning'];
+        }
+
+        $enabledIds = $repository->enabledIds();
+        $isEnabled  = in_array($pluginId, $enabledIds, true);
+
+        if ($isEnabled) {
+            if (!$plugin->manifest->removable) {
+                return ["„{$plugin->manifest->name}\u{201c} ist fester Bestandteil und kann nicht deaktiviert werden.", 'warning'];
+            }
+            $dependents = $this->enabledDependents($pluginId, $registry, $enabledIds);
+            if ($dependents !== []) {
+                return [
+                    "„{$plugin->manifest->name}\u{201c} wird noch benötigt von: " . implode(', ', $dependents) . '. Bitte zuerst dort deaktivieren.',
+                    'warning',
+                ];
+            }
+            $repository->setEnabled($pluginId, false);
+            return ["„{$plugin->manifest->name}\u{201c} wurde deaktiviert. Daten und Tabellen bleiben erhalten.", 'success'];
+        }
+
+        // Aktivieren: fehlende Abhängigkeiten benennen statt still zu scheitern.
+        $missing = [];
+        foreach ($plugin->manifest->depends as $dep) {
+            if (!in_array($dep, $enabledIds, true)) {
+                $depPlugin = $registry->get($dep);
+                $missing[] = $depPlugin?->manifest->name ?? $dep;
+            }
+        }
+        if ($missing !== []) {
+            return [
+                "„{$plugin->manifest->name}\u{201c} benötigt zuerst: " . implode(', ', $missing) . '.',
+                'warning',
+            ];
+        }
+
+        $repository->setEnabled($pluginId, true);
+        return ["„{$plugin->manifest->name}\u{201c} wurde aktiviert.", 'success'];
+    }
+
+    /**
+     * Namen aller AKTIVIERTEN Plugins, die auf $pluginId angewiesen sind.
+     *
+     * @param list<string> $enabledIds
+     * @return list<string>
+     */
+    private function enabledDependents(string $pluginId, PluginRegistry $registry, array $enabledIds): array
+    {
+        $names = [];
+        foreach ($registry->all() as $id => $plugin) {
+            if ($id === $pluginId || !in_array($id, $enabledIds, true)) {
+                continue;
+            }
+            if (in_array($pluginId, $plugin->manifest->depends, true)) {
+                $names[] = $plugin->manifest->name;
+            }
+        }
+        return $names;
+    }
+}

--- a/src/Plugins/PluginLoader.php
+++ b/src/Plugins/PluginLoader.php
@@ -22,6 +22,28 @@ use PDO;
  */
 class PluginLoader
 {
+    /**
+     * Offiziell mitgelieferte Plugins. Die Liste lebt bewusst im Core und
+     * nicht in den Manifesten — ein fremdes Plugin könnte sich sonst
+     * selbst zum vertrauenswürdigen Bestandteil erklären. Nur Plugins auf
+     * dieser Liste gelten ohne manuelle Installation als installiert.
+     */
+    public const BUNDLED = [
+        'knowledge-base',
+        'manv-board',
+        'enotf',
+        'firetab',
+    ];
+
+    /**
+     * Marker-Datei, die ein manuell installiertes (nicht mitgeliefertes)
+     * Plugin als freigegeben kennzeichnet. Eine Datei statt eines
+     * DB-Flags, damit auch phinx.php — das ohne Datenbank in der CLI
+     * läuft — installierte von bloß hochkopierten Plugins unterscheiden
+     * kann.
+     */
+    private const INSTALLED_MARKER = '.installed';
+
     /** @var list<Plugin>|null */
     private ?array $active = null;
 
@@ -34,20 +56,59 @@ class PluginLoader
         return dirname(__DIR__, 2) . '/plugins';
     }
 
+    public static function isBundled(string $pluginId): bool
+    {
+        return in_array($pluginId, self::BUNDLED, true);
+    }
+
     /**
-     * Migrations-Verzeichnisse ALLER installierten Plugins — bewusst ohne
+     * Installiert = mitgeliefert ODER vom Admin ausdrücklich freigegeben.
+     * Nicht installierte Plugins werden weder geladen noch migriert —
+     * ein nach plugins/ kopiertes Fremd-Archiv führt keinerlei Code aus,
+     * bis jemand die Installation bewusst startet.
+     */
+    public static function isInstalledDir(string $pluginId, string $directory): bool
+    {
+        return self::isBundled($pluginId)
+            || is_file($directory . DIRECTORY_SEPARATOR . self::INSTALLED_MARKER);
+    }
+
+    public static function isInstalled(Plugin $plugin): bool
+    {
+        return self::isInstalledDir($plugin->id(), $plugin->directory);
+    }
+
+    /**
+     * Kennzeichnet ein Fremd-Plugin als installiert. Erst danach nimmt
+     * der Migrationslauf seine Migrations mit und der Loader lädt es.
+     */
+    public static function markInstalled(Plugin $plugin): bool
+    {
+        $marker = $plugin->directory . DIRECTORY_SEPARATOR . self::INSTALLED_MARKER;
+        return @file_put_contents($marker, date('c') . "\n") !== false;
+    }
+
+    /**
+     * Migrations-Verzeichnisse aller INSTALLIERTEN Plugins — bewusst ohne
      * Blick in die Datenbank. Schema-Migrationen laufen auch für
-     * deaktivierte Plugins, damit Deaktivieren nie Daten oder Schema
-     * zurücklässt, das beim Reaktivieren fehlt. Außerdem wird diese Liste
-     * von phinx.php gebraucht, das auch ohne App-Bootstrap (CLI) läuft.
+     * deaktivierte (aber installierte) Plugins, damit Deaktivieren nie
+     * Daten oder Schema zurücklässt, das beim Reaktivieren fehlt. Diese
+     * Liste wird auch von phinx.php gebraucht, das ohne App-Bootstrap in
+     * der CLI läuft.
      *
      * @return list<string>
      */
     public static function migrationPaths(): array
     {
-        $dirs = glob(self::pluginsDir() . '/*/migrations', GLOB_ONLYDIR) ?: [];
-        sort($dirs);
-        return array_values($dirs);
+        $paths = [];
+        foreach (glob(self::pluginsDir() . '/*/migrations', GLOB_ONLYDIR) ?: [] as $dir) {
+            $pluginId = basename(dirname($dir));
+            if (self::isInstalledDir($pluginId, dirname($dir))) {
+                $paths[] = $dir;
+            }
+        }
+        sort($paths);
+        return array_values($paths);
     }
 
     /**
@@ -69,7 +130,26 @@ class PluginLoader
 
             $repository = new PluginRepository($this->pdo);
             $repository->syncDiscovered($registry->all());
-            $registry->resolve($repository->enabledIds(), self::ignisVersion());
+
+            // Nur installierte Plugins kommen in die Auflösung — ein bloß
+            // nach plugins/ kopiertes Fremd-Plugin bleibt vollständig
+            // inert, bis der Admin die Installation ausdrücklich startet.
+            $enabledIds = array_values(array_filter(
+                $repository->enabledIds(),
+                function (string $id) use ($registry): bool {
+                    $plugin = $registry->get($id);
+                    if ($plugin === null) {
+                        return false;
+                    }
+                    if (!self::isInstalled($plugin)) {
+                        Logger::warning("Plugin '{$id}' übersprungen: Installation wurde noch nicht bestätigt.");
+                        return false;
+                    }
+                    return true;
+                },
+            ));
+
+            $registry->resolve($enabledIds, self::ignisVersion());
 
             foreach ($registry->skipped() as $skip) {
                 Logger::warning("Plugin '{$skip['id']}' übersprungen: {$skip['reason']}");

--- a/templates/settings/system/plugins.php
+++ b/templates/settings/system/plugins.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * View: Plugin-Verwaltung
+ *
+ * @var \PDO                                $pdo
+ * @var list<array{id: string, manifest: \App\Plugins\PluginManifest, enabled: bool, active: bool, skipReason: ?string, requiredBy: list<string>}> $rows
+ * @var string                              $message
+ * @var string                              $messageType
+ */
+
+use App\Security\CsrfProtection;
+
+$csrfToken = CsrfProtection::getToken();
+?>
+<!DOCTYPE html>
+<html lang="de" data-bs-theme="dark">
+
+<head>
+    <?php
+    $SITE_TITLE = 'Plugins';
+    include __DIR__ . '/../../../assets/components/_base/admin/head.php';
+    ?>
+</head>
+
+<body data-bs-theme="dark" data-page="settings">
+    <?php include __DIR__ . "/../../../assets/components/navbar.php"; ?>
+    <div class="container-full relative" id="mainpageContainer">
+        <div class="container mx-auto">
+            <div class="mb-6">
+                <div class="mb-4 flex items-center justify-between">
+                    <h1 class="mb-0">Plugins</h1>
+                </div>
+
+                <p class="text-gray-400 mb-4" style="max-width: 720px;">
+                    Module, die als Plugin ausgeliefert werden, lassen sich hier einzeln
+                    aktivieren oder deaktivieren. Beim Deaktivieren verschwinden Navigation,
+                    Routen und Berechtigungen des Moduls — <strong>alle Daten und Tabellen
+                    bleiben erhalten</strong> und stehen nach dem Reaktivieren unverändert
+                    wieder zur Verfügung.
+                </p>
+                <p class="text-gray-400 mb-4" style="max-width: 720px; font-size: 0.85rem;">
+                    <i class="fa-solid fa-shield-halved mr-1"></i>
+                    Nicht offiziell mitgelieferte Plugins bleiben nach dem Hochladen zunächst
+                    vollständig inaktiv: Es wird kein Code ausgeführt und keine Migration
+                    angewendet, bis die Installation hier ausdrücklich gestartet wird.
+                </p>
+
+                <?php if ($message !== ''): ?>
+                    <div class="alert alert-<?= htmlspecialchars($messageType) ?> mb-4" role="alert">
+                        <?= htmlspecialchars($message) ?>
+                    </div>
+                <?php endif; ?>
+
+                <?php if ($rows === []): ?>
+                    <div class="intra__tile p-4 text-gray-400">
+                        Keine Plugins installiert.
+                    </div>
+                <?php endif; ?>
+
+                <?php foreach ($rows as $row): ?>
+                    <?php $m = $row['manifest']; ?>
+                    <div class="intra__tile mb-3 p-3">
+                        <div class="flex flex-wrap items-center gap-3">
+                            <div class="flex-1" style="min-width: 260px;">
+                                <div class="flex flex-wrap items-center gap-2">
+                                    <strong><?= htmlspecialchars($m->name) ?></strong>
+                                    <span class="badge text-bg-secondary"><?= htmlspecialchars($m->version) ?></span>
+                                    <?php if (!$row['installed']): ?>
+                                        <span class="badge text-bg-danger">Nicht installiert</span>
+                                    <?php elseif ($row['active']): ?>
+                                        <span class="badge text-bg-success">Aktiv</span>
+                                    <?php elseif ($row['enabled'] && $row['skipReason'] !== null): ?>
+                                        <span class="badge text-bg-warning" title="<?= htmlspecialchars($row['skipReason']) ?>">Übersprungen</span>
+                                    <?php else: ?>
+                                        <span class="badge text-bg-dark">Inaktiv</span>
+                                    <?php endif; ?>
+                                    <?php if ($row['bundled']): ?>
+                                        <span class="badge text-bg-primary" title="Offiziell mit ıgnıs ausgeliefert.">Offiziell</span>
+                                    <?php endif; ?>
+                                    <?php if (!$m->removable): ?>
+                                        <span class="badge text-bg-info" title="Dieses Plugin ist fester Bestandteil und kann nicht deaktiviert werden.">Erforderlich</span>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="text-gray-400 mt-1" style="font-size: 0.82rem;">
+                                    von <?= htmlspecialchars($m->vendor) ?>
+                                    <?php if ($m->depends !== []): ?>
+                                        &middot; benötigt: <?= htmlspecialchars(implode(', ', $m->depends)) ?>
+                                    <?php endif; ?>
+                                    <?php if ($row['requiredBy'] !== []): ?>
+                                        &middot; benötigt von: <?= htmlspecialchars(implode(', ', $row['requiredBy'])) ?>
+                                    <?php endif; ?>
+                                </div>
+                                <?php if ($row['enabled'] && $row['skipReason'] !== null): ?>
+                                    <div class="text-warning mt-1" style="font-size: 0.82rem;">
+                                        <i class="fa-solid fa-triangle-exclamation mr-1"></i><?= htmlspecialchars($row['skipReason']) ?>
+                                    </div>
+                                <?php endif; ?>
+                            </div>
+                            <div class="shrink-0">
+                                <?php if (!$row['installed']): ?>
+                                    <form method="post" class="inline"
+                                        onsubmit="return confirm('ACHTUNG: <?= htmlspecialchars($m->name, ENT_QUOTES) ?> ist KEIN offiziell mitgeliefertes Plugin. Die Installation führt fremden Code aus und wendet dessen Datenbank-Migrationen an. Nur fortfahren, wenn du der Quelle vertraust. Jetzt installieren?');">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                                        <input type="hidden" name="plugin_action" value="install">
+                                        <input type="hidden" name="plugin_id" value="<?= htmlspecialchars($row['id']) ?>">
+                                        <button type="submit" class="ignis-btn ignis-btn--sm ignis-btn--soft-warning">
+                                            <i class="fa-solid fa-triangle-exclamation mr-1"></i>Installieren
+                                        </button>
+                                    </form>
+                                <?php elseif ($row['enabled']): ?>
+                                    <?php $blocked = !$m->removable || $row['requiredBy'] !== []; ?>
+                                    <form method="post" class="inline"
+                                        <?php if (!$blocked): ?>onsubmit="return confirm('Plugin <?= htmlspecialchars($m->name, ENT_QUOTES) ?> wirklich deaktivieren? Daten bleiben erhalten.');"<?php endif; ?>>
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                                        <input type="hidden" name="plugin_id" value="<?= htmlspecialchars($row['id']) ?>">
+                                        <button type="submit" class="ignis-btn ignis-btn--sm ignis-btn--soft-danger" <?= $blocked ? 'disabled' : '' ?>
+                                            <?php if (!$m->removable): ?>title="Fester Bestandteil — nicht deaktivierbar"<?php elseif ($row['requiredBy'] !== []): ?>title="Wird von anderen aktiven Plugins benötigt"<?php endif; ?>>
+                                            Deaktivieren
+                                        </button>
+                                    </form>
+                                <?php else: ?>
+                                    <form method="post" class="inline">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                                        <input type="hidden" name="plugin_id" value="<?= htmlspecialchars($row['id']) ?>">
+                                        <button type="submit" class="ignis-btn ignis-btn--sm ignis-btn--soft-primary">
+                                            Aktivieren
+                                        </button>
+                                    </form>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+
+            </div>
+        </div>
+    </div>
+    <?php include __DIR__ . "/../../../assets/components/footer.php"; ?>
+</body>
+
+</html>

--- a/tests/Unit/Plugins/PluginLoaderTest.php
+++ b/tests/Unit/Plugins/PluginLoaderTest.php
@@ -129,6 +129,38 @@ class PluginLoaderTest extends TestCase
     }
 
     #[Test]
+    public function bundled_plugins_count_as_installed_without_a_marker(): void
+    {
+        $this->assertTrue(PluginLoader::isBundled('knowledge-base'));
+        $this->assertTrue(PluginLoader::isInstalledDir('knowledge-base', sys_get_temp_dir()));
+    }
+
+    #[Test]
+    public function third_party_plugins_require_the_install_marker(): void
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ignis-plugin-gate-' . getmypid();
+        mkdir($dir, 0777, true);
+
+        try {
+            $this->assertFalse(PluginLoader::isBundled('community-thing'));
+            $this->assertFalse(
+                PluginLoader::isInstalledDir('community-thing', $dir),
+                'ohne Marker gilt ein Fremd-Plugin als nicht installiert'
+            );
+
+            $plugin = new Plugin(
+                PluginManifest::fromArray(['id' => 'community-thing', 'name' => 'Community Thing', 'version' => '1.0.0']),
+                $dir
+            );
+            $this->assertTrue(PluginLoader::markInstalled($plugin));
+            $this->assertTrue(PluginLoader::isInstalledDir('community-thing', $dir));
+        } finally {
+            @unlink($dir . DIRECTORY_SEPARATOR . '.installed');
+            @rmdir($dir);
+        }
+    }
+
+    #[Test]
     public function plugins_without_fragments_contribute_nothing(): void
     {
         // Manifest-only Plugin: kein navigation.php, events.php, …


### PR DESCRIPTION
Adds **Einstellungen -> System -> Plugins**: every discovered plugin with version, vendor, dependencies and state (Aktiv / Inaktiv / Uebersprungen with reason / Nicht installiert), plus enable/disable controls. Disabling confirms first, is blocked while another enabled plugin depends on the module or the manifest says non-removable, and never touches data. Enabling names missing dependencies. CSRF-protected, admin-only.

**Safety gate (the important part):** only ids on the core-owned `PluginLoader::BUNDLED` list count as installed automatically - the trust anchor deliberately does not live in the manifest, where a third-party plugin could claim it. Anything else dropped into `plugins/` stays completely inert (no code, no migrations) until an admin explicitly starts the installation on this page. That writes an `.installed` marker into the plugin folder (a file, not a DB flag, so `phinx.php` can apply the same filter database-free in the CLI), runs the migrations and enables the plugin. The confirm dialog says in plain words that this executes third-party code.

`migrationPaths()` and the loader''s active set respect the gate; unit tests cover bundled/marker behaviour. The four planned first-party plugins are pre-listed in BUNDLED, so their upcoming extractions need no further steps here.