### PR TITLE
Link the plugins page and polish the announcements trigger

### DIFF
--- a/assets/components/footer.php
+++ b/assets/components/footer.php
@@ -43,31 +43,47 @@ $__footerVersion = is_array($__footerVersionInfo) && !empty($__footerVersionInfo
 <?php if ($__footerVersion !== null): ?>
     <dialog id="ignis-about-dialog" class="ignis-about-dialog">
         <div class="ignis-about-head">
-            <strong>ıgnıs <?= htmlspecialchars($__footerVersion) ?></strong>
-            <button type="button" onclick="this.closest('dialog').close()" aria-label="Schließen">✕</button>
+            <div>
+                <span class="ignis-about-brand"><em><strong>ıgnıs</strong></em></span>
+                <span class="ignis-about-version"><?= htmlspecialchars($__footerVersion) ?></span>
+                <div class="ignis-about-tagline">Struktur für jeden Einsatz.</div>
+            </div>
+            <button type="button" onclick="this.closest('dialog').close()" aria-label="Schließen">
+                <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+            </button>
         </div>
         <div class="ignis-about-body">
             <p>
-                <em><strong>ıgnıs</strong></em> wird von
+                Entwickelt von
                 <a href="https://emergencyforge.de" target="_blank" rel="nofollow">EmergencyForge</a>
-                unter Mitarbeit von hypax, QuitScope, bitsystem und der Community entwickelt.
+                unter Mitarbeit der Community.
             </p>
-            <p>
-                Lizenziert unter der
-                <a href="https://github.com/EmergencyForge/ignis/blob/main/LICENSE.md" target="_blank" rel="nofollow">GNU General Public License v3.0</a>
-                — Quellcode auf
-                <a href="https://github.com/EmergencyForge/ignis" target="_blank" rel="nofollow">GitHub</a>.
-            </p>
-            <p class="ignis-about-credits">
-                Baut auf großartiger Open-Source-Arbeit auf:
-                <a href="https://fontawesome.com/" target="_blank" rel="nofollow">Font Awesome</a> ·
-                <a href="https://ckeditor.com/" target="_blank" rel="nofollow">CKEditor</a> ·
-                <a href="https://fonts.google.com/" target="_blank" rel="nofollow">Google Fonts</a> ·
-                <a href="https://www.chartjs.org/" target="_blank" rel="nofollow">Chart.js</a> ·
-                <a href="https://github.com/SortableJS/Sortable" target="_blank" rel="nofollow">SortableJS</a> ·
-                <a href="https://taktische-zeichen.dev/" target="_blank" rel="nofollow">Taktische Zeichen</a> ·
-                <a href="https://leafletjs.com/" target="_blank" rel="nofollow">Leaflet</a>
-            </p>
+            <div class="ignis-about-chips">
+                <span class="ignis-about-chip"><i class="fa-solid fa-code" aria-hidden="true"></i> hypax</span>
+                <span class="ignis-about-chip"><i class="fa-solid fa-code" aria-hidden="true"></i> QuitScope</span>
+                <span class="ignis-about-chip"><i class="fa-solid fa-code" aria-hidden="true"></i> bitsystem</span>
+                <span class="ignis-about-chip"><i class="fa-solid fa-heart" aria-hidden="true"></i> Community</span>
+            </div>
+            <div class="ignis-about-actions">
+                <a class="ignis-about-action" href="https://github.com/EmergencyForge/ignis" target="_blank" rel="nofollow">
+                    <i class="fa-brands fa-github" aria-hidden="true"></i> Quellcode
+                </a>
+                <a class="ignis-about-action" href="https://github.com/EmergencyForge/ignis/blob/main/LICENSE.md" target="_blank" rel="nofollow">
+                    <i class="fa-solid fa-scale-balanced" aria-hidden="true"></i> GPL-3.0-Lizenz
+                </a>
+            </div>
+        </div>
+        <div class="ignis-about-credits">
+            <div class="ignis-about-credits-label">Baut auf großartiger Open-Source-Arbeit</div>
+            <div class="ignis-about-chips">
+                <a class="ignis-about-chip" href="https://fontawesome.com/" target="_blank" rel="nofollow">Font Awesome</a>
+                <a class="ignis-about-chip" href="https://ckeditor.com/" target="_blank" rel="nofollow">CKEditor</a>
+                <a class="ignis-about-chip" href="https://fonts.google.com/" target="_blank" rel="nofollow">Google Fonts</a>
+                <a class="ignis-about-chip" href="https://www.chartjs.org/" target="_blank" rel="nofollow">Chart.js</a>
+                <a class="ignis-about-chip" href="https://github.com/SortableJS/Sortable" target="_blank" rel="nofollow">SortableJS</a>
+                <a class="ignis-about-chip" href="https://taktische-zeichen.dev/" target="_blank" rel="nofollow">Taktische Zeichen</a>
+                <a class="ignis-about-chip" href="https://leafletjs.com/" target="_blank" rel="nofollow">Leaflet</a>
+            </div>
         </div>
     </dialog>
     <style>
@@ -88,13 +104,15 @@ $__footerVersion = is_array($__footerVersionInfo) && !empty($__footerVersionInfo
         .ignis-about-dialog {
             margin: auto;
             /* globale Resets nullen sonst das zentrierende UA-margin */
-            border: 1px solid rgba(255, 255, 255, 0.15);
-            border-radius: 10px;
-            background: #1c1c1e;
+            border: 1px solid var(--darkgray, #3d3a44);
+            border-radius: 14px;
+            background: #29282f;
             color: #e1e1e1;
             padding: 0;
-            max-width: 26rem;
+            max-width: 27rem;
             width: calc(100vw - 2rem);
+            overflow: hidden;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
         }
 
         .ignis-about-dialog::backdrop {
@@ -104,9 +122,34 @@ $__footerVersion = is_array($__footerVersionInfo) && !empty($__footerVersionInfo
         .ignis-about-head {
             display: flex;
             justify-content: space-between;
-            align-items: center;
-            padding: 0.75rem 1.25rem;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            align-items: flex-start;
+            padding: 1.1rem 1.25rem 1rem;
+            border-bottom: 1px solid var(--darkgray, #3d3a44);
+        }
+
+        .ignis-about-brand {
+            font-size: 1.35rem;
+            color: var(--main-color, #d3572f);
+            letter-spacing: 0.01em;
+        }
+
+        .ignis-about-version {
+            display: inline-block;
+            margin-left: 0.5rem;
+            padding: 0.1rem 0.5rem;
+            border: 1px solid var(--darkgray, #3d3a44);
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.04);
+            font-family: ui-monospace, monospace;
+            font-size: 0.72rem;
+            color: #b7b7bd;
+            vertical-align: 0.25em;
+        }
+
+        .ignis-about-tagline {
+            margin-top: 0.15rem;
+            font-size: 0.78rem;
+            color: #8f8f97;
         }
 
         .ignis-about-head button {
@@ -115,6 +158,8 @@ $__footerVersion = is_array($__footerVersionInfo) && !empty($__footerVersionInfo
             color: #9a9a9a;
             cursor: pointer;
             font-size: 1rem;
+            padding: 0.25rem;
+            line-height: 1;
         }
 
         .ignis-about-head button:hover {
@@ -122,25 +167,87 @@ $__footerVersion = is_array($__footerVersionInfo) && !empty($__footerVersionInfo
         }
 
         .ignis-about-body {
-            padding: 1rem 1.25rem 1.25rem;
+            padding: 1.1rem 1.25rem;
             font-size: 0.875rem;
             line-height: 1.6;
         }
 
-        .ignis-about-body p+p {
-            margin-top: 0.75rem;
-        }
-
-        .ignis-about-credits {
-            font-size: 0.78rem;
-            color: #9a9a9a;
-            border-top: 1px solid rgba(255, 255, 255, 0.1);
-            padding-top: 0.75rem;
+        .ignis-about-body p {
+            margin-bottom: 0.6rem;
         }
 
         .ignis-about-body a {
             color: inherit;
             text-decoration: underline;
+        }
+
+        .ignis-about-chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+        }
+
+        .ignis-about-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.2rem 0.6rem;
+            border: 1px solid var(--darkgray, #3d3a44);
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.04);
+            font-size: 0.75rem;
+            color: #c9c9cf;
+            text-decoration: none !important;
+        }
+
+        .ignis-about-chip i {
+            font-size: 0.65rem;
+            color: var(--main-color, #d3572f);
+        }
+
+        a.ignis-about-chip:hover {
+            border-color: var(--main-color, #d3572f);
+            color: #fff;
+        }
+
+        .ignis-about-actions {
+            display: flex;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .ignis-about-action {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            padding: 0.4rem 0.85rem;
+            border: 1px solid var(--darkgray, #3d3a44);
+            border-radius: 8px;
+            background: rgba(255, 255, 255, 0.04);
+            font-size: 0.8rem;
+            color: #e1e1e1;
+            text-decoration: none !important;
+            transition: border-color 0.15s ease, background 0.15s ease;
+        }
+
+        .ignis-about-action:hover {
+            border-color: var(--main-color, #d3572f);
+            background: rgba(255, 255, 255, 0.07);
+        }
+
+        .ignis-about-credits {
+            padding: 0.9rem 1.25rem 1.1rem;
+            border-top: 1px solid var(--darkgray, #3d3a44);
+            background: rgba(0, 0, 0, 0.15);
+        }
+
+        .ignis-about-credits-label {
+            font-size: 0.68rem;
+            font-weight: 600;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: #8f8f97;
+            margin-bottom: 0.5rem;
         }
     </style>
 <?php endif; ?>

--- a/assets/components/global-announcements.php
+++ b/assets/components/global-announcements.php
@@ -215,17 +215,71 @@ $allAnnouncementIds = array_column($announcements, 'announcement_id');
 
 <!-- Trigger Button für manuelles Öffnen -->
 <div id="efAnnouncementsTrigger" class="fixed" style="bottom: 20px; right: 20px; z-index: 1040; display: none;">
-    <button type="button" class="ignis-btn btn-<?= $hasCritical ? 'danger' : ($hasWarning ? 'warning' : 'primary') ?> rounded-full shadow-lg relative"
-        data-bs-toggle="modal" data-bs-target="#efAnnouncementsModal">
-        <i class="fa-solid fa-bullhorn mr-2"></i>
-        <span class="hidden d-sm-inline"><?= count($announcements) ?> Ankündigung<?= count($announcements) > 1 ? 'en' : '' ?></span>
-        <span class="absolute top-0 start-100 translate-middle ignis-chip rounded-full bg-[#b03a3a] sm:hidden">
-            <?= count($announcements) ?>
-        </span>
+    <button type="button"
+        class="ef-announce-fab ef-announce-fab--<?= $hasCritical ? 'critical' : ($hasWarning ? 'warning' : 'info') ?>"
+        data-bs-toggle="modal" data-bs-target="#efAnnouncementsModal"
+        title="<?= count($announcements) ?> Ankündigung<?= count($announcements) > 1 ? 'en' : '' ?>"
+        aria-label="<?= count($announcements) ?> Ankündigung<?= count($announcements) > 1 ? 'en' : '' ?> anzeigen">
+        <i class="fa-solid fa-bullhorn" aria-hidden="true"></i>
+        <span class="ef-announce-fab__count"><?= count($announcements) ?></span>
     </button>
 </div>
 
 <style>
+    /* Floating-Trigger unten rechts: quadratisch mit leichter Rundung,
+       Zähler als Eck-Badge. Bewusst eigene Klasse statt ignis-btn —
+       der FAB hat feste Maße und eigene Severity-Farben. */
+    .ef-announce-fab {
+        width: 46px;
+        height: 46px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 12px;
+        color: #fff;
+        font-size: 1.05rem;
+        cursor: pointer;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .ef-announce-fab:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.55);
+    }
+
+    .ef-announce-fab--info {
+        background: var(--btn-primary-bg, #4a6fa5);
+    }
+
+    .ef-announce-fab--warning {
+        background: #a87b2d;
+    }
+
+    .ef-announce-fab--critical {
+        background: #b03a3a;
+    }
+
+    .ef-announce-fab__count {
+        position: absolute;
+        top: -6px;
+        right: -6px;
+        min-width: 20px;
+        height: 20px;
+        padding: 0 5px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #b03a3a;
+        border: 2px solid #1c1b21;
+        border-radius: 999px;
+        font-size: 0.7rem;
+        font-weight: 700;
+        line-height: 1;
+    }
+
     /* EmergencyForge Announcements Modal Styles */
     #efAnnouncementsModal .ef-modal-content {
         background: #29282f;

--- a/assets/components/index/setup-checklist.php
+++ b/assets/components/index/setup-checklist.php
@@ -37,6 +37,9 @@ try {
 } catch (Exception $e) {
 }
 
+// POIs gehören zum eNOTF-Plugin — ohne aktives Plugin entfällt der Schritt.
+$setupEnotfActive = function_exists('app') && app(\App\Plugins\PluginLoader::class)->isActive('enotf');
+
 $checkDienstgrade = _setupCount($pdo, 'intra_mitarbeiter_dienstgrade');
 $checkQuali       = _setupCount($pdo, 'intra_mitarbeiter_rdquali');
 $checkRollen      = _setupCount($pdo, 'intra_users_roles');
@@ -56,10 +59,10 @@ $doneFahrzeuge    = $checkFahrzeuge > 0;
 // Required steps (must all be done to hide checklist)
 $requiredSteps = 5;
 $completedRequired = (int)$doneConfig + (int)$doneDienstgrade + (int)$doneQuali + (int)$doneRollen + (int)$doneMitarbeiter;
-$completedOptional = (int)$donePois + (int)$doneFahrzeuge;
+$completedOptional = ($setupEnotfActive ? (int)$donePois : 0) + (int)$doneFahrzeuge;
 
 $totalDisplay = $completedRequired + $completedOptional;
-$totalAll = $requiredSteps + 2;
+$totalAll = $requiredSteps + ($setupEnotfActive ? 2 : 1);
 
 // Don't show if all required steps are done
 if ($completedRequired >= $requiredSteps) return;
@@ -134,14 +137,16 @@ $stepNum = 1;
     <div style="margin-top:0.75rem;padding-top:0.6rem;border-top:1px solid var(--darkgray);">
         <div style="font-size:var(--fs-xs);color:var(--text-dimmed);text-transform:uppercase;letter-spacing:0.04em;margin-bottom:0.4rem;">Optional</div>
         <div class="setup-steps">
-            <?php $done = $donePois; ?>
-            <a href="<?= BASE_PATH ?>settings/pois/index" class="setup-step <?= $done ? 'done' : '' ?>">
-                <span class="setup-step-icon" style="background:rgba(255,255,255,0.06);color:var(--text-dimmed);"><?= $done ? '<i class="fa-solid fa-check"></i>' : '<i class="fa-solid fa-map-marker-alt" style="font-size:0.65rem"></i>' ?></span>
-                <span class="setup-step-text">
-                    <strong>POIs einrichten</strong>
-                    <small>Einsatzorte und Krankenhäuser auf der Karte</small>
-                </span>
-            </a>
+            <?php if ($setupEnotfActive): ?>
+                <?php $done = $donePois; ?>
+                <a href="<?= BASE_PATH ?>settings/pois/index" class="setup-step <?= $done ? 'done' : '' ?>">
+                    <span class="setup-step-icon" style="background:rgba(255,255,255,0.06);color:var(--text-dimmed);"><?= $done ? '<i class="fa-solid fa-check"></i>' : '<i class="fa-solid fa-map-marker-alt" style="font-size:0.65rem"></i>' ?></span>
+                    <span class="setup-step-text">
+                        <strong>POIs einrichten</strong>
+                        <small>Einsatzorte und Krankenhäuser auf der Karte</small>
+                    </span>
+                </a>
+            <?php endif; ?>
 
             <?php $done = $doneFahrzeuge; ?>
             <a href="<?= BASE_PATH ?>settings/vehicles/vehicles/index" class="setup-step <?= $done ? 'done' : '' ?>">

--- a/assets/components/index/stats.php
+++ b/assets/components/index/stats.php
@@ -1,11 +1,11 @@
 <?php
-// Optimiert: Eine UNION-Query statt 4 separate Queries
+// Optimiert: Eine UNION-Query statt separater Queries. Die eNOTF-Zahl
+// läuft getrennt — intra_edivi gehört zum Plugin, und eine fehlende
+// Tabelle würde sonst die komplette UNION (alle vier Werte) reißen.
 $statsQuery = "
     SELECT 'users' as stat_type, COUNT(*) as stat_count FROM intra_users
     UNION ALL
     SELECT 'mitarbeiter', COUNT(*) FROM intra_mitarbeiter
-    UNION ALL
-    SELECT 'enotf', COUNT(*) FROM intra_edivi
     UNION ALL
     SELECT 'dokumente', COUNT(*) FROM intra_mitarbeiter_dokumente
 ";
@@ -13,6 +13,15 @@ $statsStmt = $pdo->query($statsQuery);
 $statsData = [];
 while ($row = $statsStmt->fetch(PDO::FETCH_ASSOC)) {
     $statsData[$row['stat_type']] = (int)$row['stat_count'];
+}
+
+$statsEnotfActive = function_exists('app') && app(\App\Plugins\PluginLoader::class)->isActive('enotf');
+if ($statsEnotfActive) {
+    try {
+        $statsData['enotf'] = (int)$pdo->query("SELECT COUNT(*) FROM intra_edivi")->fetchColumn();
+    } catch (Exception) {
+        $statsEnotfActive = false;
+    }
 }
 ?>
 <div class="intra__stats-strip">
@@ -24,10 +33,12 @@ while ($row = $statsStmt->fetch(PDO::FETCH_ASSOC)) {
         <span class="intra__stat-value" data-count-to="<?= (int)($statsData['mitarbeiter'] ?? 0) ?>">0</span>
         <span class="intra__stat-label">Mitarbeiter</span>
     </div>
-    <div class="intra__stat-item">
-        <span class="intra__stat-value" data-count-to="<?= (int)($statsData['enotf'] ?? 0) ?>">0</span>
-        <span class="intra__stat-label">eNOTF-Protokolle</span>
-    </div>
+    <?php if ($statsEnotfActive): ?>
+        <div class="intra__stat-item">
+            <span class="intra__stat-value" data-count-to="<?= (int)($statsData['enotf'] ?? 0) ?>">0</span>
+            <span class="intra__stat-label">eNOTF-Protokolle</span>
+        </div>
+    <?php endif; ?>
     <div class="intra__stat-item">
         <span class="intra__stat-value" data-count-to="<?= (int)($statsData['dokumente'] ?? 0) ?>">0</span>
         <span class="intra__stat-label">Dokumente</span>

--- a/assets/components/navbar.php
+++ b/assets/components/navbar.php
@@ -1553,7 +1553,7 @@ $roleHex = $roleColorMap[$roleColor] ?? '#6c757d';
                         <?php endif; ?>
                     <?php endif; ?>
 
-                    <?php if (Permissions::check(['admin', 'edivi.view', 'pois.view'])): ?>
+                    <?php if (app(\App\Plugins\PluginLoader::class)->isActive('enotf') && Permissions::check(['admin', 'edivi.view', 'pois.view'])): ?>
                         <span class="sidebar-section-title" data-section="enotf-settings">eNOTF</span>
                         <?php if (Permissions::check(['admin', 'pois.view'])): ?>
                             <a href="<?= BASE_PATH ?>settings/pois/index" class="sidebar-sublink">POIs</a>

--- a/assets/components/navbar.php
+++ b/assets/components/navbar.php
@@ -1569,9 +1569,11 @@ $roleHex = $roleColorMap[$roleColor] ?? '#6c757d';
                     <?php if (Permissions::check(['admin'])): ?>
                         <a href="<?= BASE_PATH ?>settings/system/config" class="sidebar-sublink">Konfiguration</a>
                         <a href="<?= BASE_PATH ?>settings/system/index" class="sidebar-sublink">Updater</a>
+                        <a href="<?= BASE_PATH ?>settings/system/plugins" class="sidebar-sublink">Plugins</a>
                         <a href="<?= BASE_PATH ?>settings/system/telemetry" class="sidebar-sublink">Telemetrie</a>
                         <a href="<?= BASE_PATH ?>settings/system/performance" class="sidebar-sublink">Performance</a>
                         <a href="<?= BASE_PATH ?>settings/system/logs" class="sidebar-sublink">Logs &amp; Errors</a>
+                        <a href="<?= BASE_PATH ?>settings/system/cron" class="sidebar-sublink">Cron-Jobs</a>
                         <a href="<?= BASE_PATH ?>settings/federation/index" class="sidebar-sublink">Instanzvernetzung</a>
                     <?php endif; ?>
                 </div>

--- a/assets/components/navbar.php
+++ b/assets/components/navbar.php
@@ -1506,10 +1506,12 @@ $roleHex = $roleColorMap[$roleColor] ?? '#6c757d';
             </div>
         </div>
 
-        <!-- Lexikon (Legacy-Modul-Folder, serviert direkt via DirectoryIndex unter /lexicon/) -->
-        <a href="<?= BASE_PATH ?>lexicon/index" class="sidebar-link" data-page="lexicon">
-            <i class="fa-solid fa-book-medical"></i><span>Lexikon</span>
-        </a>
+        <!-- Lexikon (Wissensdatenbank-Plugin) -->
+        <?php if (app(\App\Plugins\PluginLoader::class)->isActive('knowledge-base')): ?>
+            <a href="<?= BASE_PATH ?>lexicon/index" class="sidebar-link" data-page="lexicon">
+                <i class="fa-solid fa-book-medical"></i><span>Lexikon</span>
+            </a>
+        <?php endif; ?>
 
         <!-- Fahrzeuge -->
         <?php if (Permissions::check(['admin', 'vehicles.view'])): ?>

--- a/src/Http/Controllers/Api/TelemetryApiController.php
+++ b/src/Http/Controllers/Api/TelemetryApiController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
-use App\Auth\Gate;
+use App\Auth\Permissions;
 use App\Http\Request;
 use App\Http\Response;
 use App\Logging\Logger;
@@ -86,7 +86,7 @@ final class TelemetryApiController
 
     private function backgroundHeartbeat(): Response
     {
-        if (!Gate::check(['admin'])) {
+        if (!Permissions::check(['admin'])) {
             return Response::json(['success' => false, 'message' => 'Nur für Admins'], 403);
         }
 

--- a/templates/settings/system/index.php
+++ b/templates/settings/system/index.php
@@ -44,6 +44,12 @@ $cards = [
         'desc' => 'System-Daten, API-Keys, Brand-Identität.',
     ],
     [
+        'href' => BASE_PATH . 'settings/system/plugins',
+        'icon' => 'fa-solid fa-puzzle-piece',
+        'title' => 'Plugins',
+        'desc' => 'Module aktivieren/deaktivieren, Community-Plugins installieren.',
+    ],
+    [
         'href' => BASE_PATH . 'settings/system/performance',
         'icon' => 'fa-solid fa-gauge-high',
         'title' => 'Performance',

--- a/templates/settings/system/plugins.php
+++ b/templates/settings/system/plugins.php
@@ -110,7 +110,7 @@ $csrfToken = CsrfProtection::getToken();
                             <div class="shrink-0">
                                 <?php if (!$row['installed']): ?>
                                     <form method="post" class="inline"
-                                        onsubmit="return confirm('ACHTUNG: <?= htmlspecialchars($m->name, ENT_QUOTES) ?> ist KEIN offiziell mitgeliefertes Plugin. Die Installation führt fremden Code aus und wendet dessen Datenbank-Migrationen an.\n\nEmergencyForge übernimmt keinerlei Gewähr für Funktion, Sicherheit oder mögliche Datenverluste durch Community-Plugins — die Nutzung erfolgt auf eigenes Risiko. Erstelle vorher ein Backup.\n\nNur fortfahren, wenn du der Quelle vertraust. Jetzt installieren?');">
+                                        onsubmit="event.preventDefault(); showConfirm('<?= htmlspecialchars($m->name, ENT_QUOTES) ?> ist KEIN offiziell mitgeliefertes Plugin. Die Installation führt fremden Code aus und wendet dessen Datenbank-Migrationen an. EmergencyForge übernimmt keinerlei Gewähr für Funktion, Sicherheit oder mögliche Datenverluste — Nutzung auf eigenes Risiko. Erstelle vorher ein Backup und fahre nur fort, wenn du der Quelle vertraust.', {title: 'Community-Plugin installieren', confirmText: 'Jetzt installieren', cancelText: 'Abbrechen', danger: true}).then(result => { if (result) this.submit(); });">
                                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
                                         <input type="hidden" name="plugin_action" value="install">
                                         <input type="hidden" name="plugin_id" value="<?= htmlspecialchars($row['id']) ?>">
@@ -121,7 +121,7 @@ $csrfToken = CsrfProtection::getToken();
                                 <?php elseif ($row['enabled']): ?>
                                     <?php $blocked = !$m->removable || $row['requiredBy'] !== []; ?>
                                     <form method="post" class="inline"
-                                        <?php if (!$blocked): ?>onsubmit="return confirm('Plugin <?= htmlspecialchars($m->name, ENT_QUOTES) ?> wirklich deaktivieren? Daten bleiben erhalten.');"<?php endif; ?>>
+                                        <?php if (!$blocked): ?>onsubmit="event.preventDefault(); showConfirm('Plugin <?= htmlspecialchars($m->name, ENT_QUOTES) ?> wirklich deaktivieren? Daten bleiben erhalten.', {title: 'Plugin deaktivieren', confirmText: 'Deaktivieren', cancelText: 'Abbrechen', danger: true}).then(result => { if (result) this.submit(); });"<?php endif; ?>>
                                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
                                         <input type="hidden" name="plugin_id" value="<?= htmlspecialchars($row['id']) ?>">
                                         <button type="submit" class="ignis-btn ignis-btn--sm ignis-btn--soft-danger" <?= $blocked ? 'disabled' : '' ?>


### PR DESCRIPTION
Findings from the dev-install click-through, all small UI/plumbing fixes:

- The plugins settings page (`/settings/system/plugins`) was only reachable by typing the URL: the legacy sidebar never got a **Plugins** entry (**Cron-Jobs** was missing there too), and the system overview page had no tile for it. Both linked now.
- The floating announcements trigger (bottom right) still mixed Bootstrap utility classes (`btn-primary`, `d-sm-inline`) with Tailwind ones — after the Bootstrap exit it collapsed into an unstyled pill. Rebuilt as a 46px square FAB with soft corners, severity-colored background and a corner count badge.
- Install/deactivate on the plugins page used browser-native `confirm()` — both go through the Dialog system (`showConfirm`) now, with proper titles and danger styling.
- The legacy sidebar's **Lexikon** link was hardcoded and survived deactivating the knowledge-base plugin — it checks `isActive('knowledge-base')` now, like the protocol sections.
- The telemetry background heartbeat 500'd on every admin page load (26× in the test instance's log): `Gate::check()` never existed — the admin guard is `Permissions::check()`.