### PR TITLE
Let the community warning span the full content width

### DIFF
--- a/templates/settings/system/plugins.php
+++ b/templates/settings/system/plugins.php
@@ -44,7 +44,7 @@ $csrfToken = CsrfProtection::getToken();
                     bleiben erhalten</strong> und stehen nach dem Reaktivieren unverändert
                     wieder zur Verfügung.
                 </p>
-                <div class="ignis-alert ignis-alert--warning mb-4" style="max-width: 720px;">
+                <div class="ignis-alert ignis-alert--warning mb-4">
                     <i class="fa-solid fa-shield-halved ignis-alert__icon"></i>
                     <div class="ignis-alert__body">
                         <div class="ignis-alert__title">Community-Plugins — Nutzung auf eigenes Risiko</div>


### PR DESCRIPTION
Follow-up to #318: the disclaimer box stopped at reading width (720px) while the plugin tiles below run full width — looked unfinished (user feedback from the dev-install test). The intro paragraph keeps its measure; the highlighted box aligns with the tiles now.