### PR TITLE
Replace leftover Bootstrap classes with ignis components

### DIFF
--- a/plugins/knowledge-base/templates/lexicon/form.php
+++ b/plugins/knowledge-base/templates/lexicon/form.php
@@ -159,7 +159,7 @@ use App\Helpers\Flash;
                     <?php Flash::render(); ?>
 
                     <?php if (!empty($errors)): ?>
-                        <div class="alert alert-danger">
+                        <div class="ignis-alert ignis-alert--danger">
                             <ul class="mb-0">
                                 <?php foreach ($errors as $error): ?>
                                     <li><?= htmlspecialchars($error) ?></li>
@@ -169,7 +169,7 @@ use App\Helpers\Flash;
                     <?php endif; ?>
 
                     <?php if ($isEdit && $entry['updated_at']): ?>
-                        <div class="alert alert-info">
+                        <div class="ignis-alert ignis-alert--info">
                             <i class="fa-solid fa-info-circle"></i>
                             Zuletzt bearbeitet am <?= date('d.m.Y H:i', strtotime($entry['updated_at'])) ?>
                             <?php if ($updaterName): ?>
@@ -436,10 +436,10 @@ use App\Helpers\Flash;
 
                         <!-- Submit Buttons -->
                         <div class="d-flex justify-content-between">
-                            <a href="<?= BASE_PATH ?>lexicon/index" class="btn btn-ghost">
+                            <a href="<?= BASE_PATH ?>lexicon/index" class="ignis-btn ignis-btn--ghost">
                                 <i class="fa-solid fa-arrow-left"></i> Abbrechen
                             </a>
-                            <button type="submit" class="btn btn-success">
+                            <button type="submit" class="ignis-btn ignis-btn--success">
                                 <i class="fa-solid fa-save"></i> <?= $isEdit ? 'Änderungen speichern' : 'Eintrag erstellen' ?>
                             </button>
                         </div>

--- a/plugins/knowledge-base/templates/lexicon/index.php
+++ b/plugins/knowledge-base/templates/lexicon/index.php
@@ -213,10 +213,10 @@ use App\KnowledgeBase\KBHelper;
                         <h1>Wissensdatenbank</h1>
                         <div class="header-actions">
                             <?php if ($isLoggedIn && Permissions::check(['admin', 'kb.edit'])): ?>
-                                <a href="<?= BASE_PATH ?>lexicon/manage-taxonomy" class="btn btn-outline-secondary">
+                                <a href="<?= BASE_PATH ?>lexicon/manage-taxonomy" class="ignis-btn ignis-btn--ghost">
                                     <i class="fa-solid fa-tags"></i> Kategorien & Tags
                                 </a>
-                                <a href="<?= BASE_PATH ?>lexicon/create" class="btn btn-success">
+                                <a href="<?= BASE_PATH ?>lexicon/create" class="ignis-btn ignis-btn--success">
                                     <i class="fa-solid fa-plus"></i> Neuer Eintrag
                                 </a>
                             <?php endif; ?>
@@ -289,7 +289,7 @@ use App\KnowledgeBase\KBHelper;
                                 </div>
                             <?php endif; ?>
                             <div class="col-auto">
-                                <button type="submit" class="btn btn-soft-primary">
+                                <button type="submit" class="ignis-btn ignis-btn--soft-primary">
                                     <i class="fa-solid fa-search"></i> Filtern
                                 </button>
                             </div>
@@ -298,7 +298,7 @@ use App\KnowledgeBase\KBHelper;
 
                     <!-- Entries Grid -->
                     <?php if (empty($entries)): ?>
-                        <div class="alert alert-info">
+                        <div class="ignis-alert ignis-alert--info">
                             <i class="fa-solid fa-info-circle"></i> Keine Einträge gefunden.
                             <?php if ($isLoggedIn && Permissions::check(['admin', 'kb.edit'])): ?>
                                 <a href="<?= BASE_PATH ?>lexicon/create">Erstellen Sie den ersten Eintrag.</a>

--- a/plugins/knowledge-base/templates/lexicon/manage-taxonomy.php
+++ b/plugins/knowledge-base/templates/lexicon/manage-taxonomy.php
@@ -30,7 +30,7 @@ use App\Helpers\Flash;
                     <div class="intra__tile p-3 mb-4">
                         <div class="d-flex justify-content-between align-items-center mb-3">
                             <h4 class="mb-0"><i class="fa-solid fa-folder-tree"></i> Kategorien</h4>
-                            <button class="btn btn-sm btn-soft-primary" onclick="showCatModal()"><i class="fa-solid fa-plus"></i> Neue Kategorie</button>
+                            <button class="ignis-btn ignis-btn--sm ignis-btn--soft-primary" onclick="showCatModal()"><i class="fa-solid fa-plus"></i> Neue Kategorie</button>
                         </div>
                         <table class="table table-striped mb-0">
                             <thead>
@@ -54,9 +54,9 @@ use App\Helpers\Flash;
                                             <td><?= (int)$cat['entry_count'] ?></td>
                                             <td>
                                                 <div class="d-flex gap-1">
-                                                    <button class="btn btn-sm btn-soft-primary btn-icon" data-tooltip="Bearbeiten" onclick='editCat(<?= json_encode($cat) ?>)'><i class="fa-solid fa-pen"></i></button>
+                                                    <button class="ignis-btn ignis-btn--sm ignis-btn--soft-primary ignis-btn--icon" data-tooltip="Bearbeiten" onclick='editCat(<?= json_encode($cat) ?>)'><i class="fa-solid fa-pen"></i></button>
                                                     <?php if ($cat['entry_count'] == 0): ?>
-                                                        <button class="btn btn-sm btn-outline-danger btn-icon" data-tooltip="Löschen" onclick="deleteCat(<?= $cat['id'] ?>, '<?= htmlspecialchars($cat['name'], ENT_QUOTES) ?>')"><i class="fa-solid fa-trash"></i></button>
+                                                        <button class="ignis-btn ignis-btn--sm ignis-btn--soft-danger ignis-btn--icon" data-tooltip="Löschen" onclick="deleteCat(<?= $cat['id'] ?>, '<?= htmlspecialchars($cat['name'], ENT_QUOTES) ?>')"><i class="fa-solid fa-trash"></i></button>
                                                     <?php endif; ?>
                                                 </div>
                                             </td>
@@ -73,7 +73,7 @@ use App\Helpers\Flash;
                     <div class="intra__tile p-3 mb-4">
                         <div class="d-flex justify-content-between align-items-center mb-3">
                             <h4 class="mb-0"><i class="fa-solid fa-tags"></i> Tags</h4>
-                            <button class="btn btn-sm btn-soft-primary" onclick="showTagModal()"><i class="fa-solid fa-plus"></i> Neuer Tag</button>
+                            <button class="ignis-btn ignis-btn--sm ignis-btn--soft-primary" onclick="showTagModal()"><i class="fa-solid fa-plus"></i> Neuer Tag</button>
                         </div>
                         <table class="table table-striped mb-0">
                             <thead>
@@ -93,8 +93,8 @@ use App\Helpers\Flash;
                                             <td><?= (int)$tag['usage_count'] ?>x</td>
                                             <td>
                                                 <div class="d-flex gap-1">
-                                                    <button class="btn btn-sm btn-soft-primary btn-icon" data-tooltip="Bearbeiten" onclick='editTag(<?= json_encode($tag) ?>)'><i class="fa-solid fa-pen"></i></button>
-                                                    <button class="btn btn-sm btn-outline-danger btn-icon" data-tooltip="Löschen" onclick="deleteTag(<?= $tag['id'] ?>, '<?= htmlspecialchars($tag['name'], ENT_QUOTES) ?>')"><i class="fa-solid fa-trash"></i></button>
+                                                    <button class="ignis-btn ignis-btn--sm ignis-btn--soft-primary ignis-btn--icon" data-tooltip="Bearbeiten" onclick='editTag(<?= json_encode($tag) ?>)'><i class="fa-solid fa-pen"></i></button>
+                                                    <button class="ignis-btn ignis-btn--sm ignis-btn--soft-danger ignis-btn--icon" data-tooltip="Löschen" onclick="deleteTag(<?= $tag['id'] ?>, '<?= htmlspecialchars($tag['name'], ENT_QUOTES) ?>')"><i class="fa-solid fa-trash"></i></button>
                                                 </div>
                                             </td>
                                         </tr>
@@ -144,8 +144,8 @@ use App\Helpers\Flash;
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-ghost" data-bs-dismiss="modal">Abbrechen</button>
-                    <button type="button" class="btn btn-primary" onclick="saveCat()"><i class="fa-solid fa-save"></i> Speichern</button>
+                    <button type="button" class="ignis-btn ignis-btn--ghost" data-bs-dismiss="modal">Abbrechen</button>
+                    <button type="button" class="ignis-btn ignis-btn--primary" onclick="saveCat()"><i class="fa-solid fa-save"></i> Speichern</button>
                 </div>
             </div>
         </div>
@@ -172,8 +172,8 @@ use App\Helpers\Flash;
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-ghost" data-bs-dismiss="modal">Abbrechen</button>
-                    <button type="button" class="btn btn-primary" onclick="saveTag()"><i class="fa-solid fa-save"></i> Speichern</button>
+                    <button type="button" class="ignis-btn ignis-btn--ghost" data-bs-dismiss="modal">Abbrechen</button>
+                    <button type="button" class="ignis-btn ignis-btn--primary" onclick="saveTag()"><i class="fa-solid fa-save"></i> Speichern</button>
                 </div>
             </div>
         </div>

--- a/plugins/knowledge-base/templates/lexicon/view.php
+++ b/plugins/knowledge-base/templates/lexicon/view.php
@@ -315,7 +315,7 @@ use App\KnowledgeBase\KBHelper;
                     <?php endif; ?>
 
                     <?php if ($entry['is_archived']): ?>
-                        <div class="alert alert-warning">
+                        <div class="ignis-alert ignis-alert--warning">
                             <i class="fa-solid fa-archive"></i> Dieser Eintrag ist archiviert.
                         </div>
                     <?php endif; ?>

--- a/templates/settings/system/plugins.php
+++ b/templates/settings/system/plugins.php
@@ -58,7 +58,7 @@ $csrfToken = CsrfProtection::getToken();
                 </div>
 
                 <?php if ($message !== ''): ?>
-                    <div class="alert alert-<?= htmlspecialchars($messageType) ?> mb-4" role="alert">
+                    <div class="ignis-alert ignis-alert--<?= htmlspecialchars($messageType) ?> mb-4" role="alert">
                         <?= htmlspecialchars($message) ?>
                     </div>
                 <?php endif; ?>
@@ -76,21 +76,21 @@ $csrfToken = CsrfProtection::getToken();
                             <div class="flex-1" style="min-width: 260px;">
                                 <div class="flex flex-wrap items-center gap-2">
                                     <strong><?= htmlspecialchars($m->name) ?></strong>
-                                    <span class="badge text-bg-secondary"><?= htmlspecialchars($m->version) ?></span>
+                                    <span class="ignis-chip"><?= htmlspecialchars($m->version) ?></span>
                                     <?php if (!$row['installed']): ?>
-                                        <span class="badge text-bg-danger">Nicht installiert</span>
+                                        <span class="ignis-chip ignis-chip--danger">Nicht installiert</span>
                                     <?php elseif ($row['active']): ?>
-                                        <span class="badge text-bg-success">Aktiv</span>
+                                        <span class="ignis-chip ignis-chip--success">Aktiv</span>
                                     <?php elseif ($row['enabled'] && $row['skipReason'] !== null): ?>
-                                        <span class="badge text-bg-warning" title="<?= htmlspecialchars($row['skipReason']) ?>">Übersprungen</span>
+                                        <span class="ignis-chip ignis-chip--warning" title="<?= htmlspecialchars($row['skipReason']) ?>">Übersprungen</span>
                                     <?php else: ?>
-                                        <span class="badge text-bg-dark">Inaktiv</span>
+                                        <span class="ignis-chip">Inaktiv</span>
                                     <?php endif; ?>
                                     <?php if ($row['bundled']): ?>
-                                        <span class="badge text-bg-primary" title="Offiziell mit ıgnıs ausgeliefert.">Offiziell</span>
+                                        <span class="ignis-chip ignis-chip--info" title="Offiziell mit ıgnıs ausgeliefert.">Offiziell</span>
                                     <?php endif; ?>
                                     <?php if (!$m->removable): ?>
-                                        <span class="badge text-bg-info" title="Dieses Plugin ist fester Bestandteil und kann nicht deaktiviert werden.">Erforderlich</span>
+                                        <span class="ignis-chip ignis-chip--info" title="Dieses Plugin ist fester Bestandteil und kann nicht deaktiviert werden.">Erforderlich</span>
                                     <?php endif; ?>
                                 </div>
                                 <div class="text-gray-400 mt-1" style="font-size: 0.82rem;">

--- a/templates/settings/system/telemetry.php
+++ b/templates/settings/system/telemetry.php
@@ -258,7 +258,7 @@ $cacheInfo = $announcements->getCacheInfo();
                                     <div class="mb-3 flex flex-wrap gap-2">
                                         <form method="POST" class="inline">
                                             <input type="hidden" name="action" value="toggle_telemetry">
-                                            <button type="submit" class="ignis-btn btn-<?= $telemetryEnabled ? 'warning' : 'success' ?>">
+                                            <button type="submit" class="ignis-btn ignis-btn--<?= $telemetryEnabled ? 'warning' : 'success' ?>">
                                                 <i class="fas fa-<?= $telemetryEnabled ? 'toggle-off' : 'toggle-on' ?> mr-1"></i>
                                                 <?= $telemetryEnabled ? 'Deaktivieren' : 'Aktivieren' ?>
                                             </button>
@@ -326,7 +326,7 @@ $cacheInfo = $announcements->getCacheInfo();
                                     <div class="mb-3 flex gap-2">
                                         <form method="POST" class="inline">
                                             <input type="hidden" name="action" value="toggle_announcements">
-                                            <button type="submit" class="ignis-btn btn-<?= $announcementsEnabled ? 'warning' : 'success' ?>">
+                                            <button type="submit" class="ignis-btn ignis-btn--<?= $announcementsEnabled ? 'warning' : 'success' ?>">
                                                 <i class="fas fa-<?= $announcementsEnabled ? 'toggle-off' : 'toggle-on' ?> mr-1"></i>
                                                 <?= $announcementsEnabled ? 'Deaktivieren' : 'Aktivieren' ?>
                                             </button>

--- a/templates/settings/vehicles/vehicles/index.php
+++ b/templates/settings/vehicles/vehicles/index.php
@@ -146,7 +146,7 @@ use App\Helpers\Flash;
                                     $defectBadge = '';
                                     if ($openDefects > 0) {
                                         $badgeColor = ($minOperable !== null && (int)$minOperable === 0) ? 'danger' : 'warning';
-                                        $defectBadge = "<a href='" . BASE_PATH . "settings/vehicles/defects/index?vehicle=" . $row['id'] . "' class='ignis-chip text-bg-{$badgeColor}' title='Offene Defekte anzeigen'>{$openDefects}</a>";
+                                        $defectBadge = "<a href='" . BASE_PATH . "settings/vehicles/defects/index?vehicle=" . $row['id'] . "' class='ignis-chip ignis-chip--{$badgeColor}' title='Offene Defekte anzeigen'>{$openDefects}</a>";
                                     } else {
                                         $defectBadge = "<span class='text-muted'>—</span>";
                                     }


### PR DESCRIPTION
Badges, alerts and buttons in the core settings pages (plugins, telemetry, vehicles) and the knowledge-base templates still used Bootstrap utility classes (`badge text-bg-*`, `alert alert-*`, `btn btn-*`) that only survive through the compat layer. They now use the existing design-system pieces: `ignis-chip` with status variants, `ignis-alert`, `ignis-btn`.

Deliberately out of scope:
- **eNOTF** keeps its own Bootstrap bundle (plugin, by design).
- **Modal attributes** (`data-bs-toggle/-dismiss`, `btn-close`, `modal fade`, 23 files) and **`data-bs-theme`** (199 files, four compat selectors key off it) — those fall to the dialog-system migration as its own project.