### PR TITLE
Make the new sidebar navigation the default

### DIFF
--- a/config/navigation.php
+++ b/config/navigation.php
@@ -47,6 +47,19 @@ return [
     'rail' => [
 
         // ─────────────────────────────────────────────────────────────
+        // Dashboard — direkter Link, kein Flyout (das Logo verlinkt
+        // ebenfalls auf die Startseite, aber ein benannter Eintrag ist
+        // auffindbarer und entspricht der alten Sidebar)
+        // ─────────────────────────────────────────────────────────────
+        [
+            'id'        => 'dashboard',
+            'label'     => 'Dashboard',
+            'icon'      => 'fa-solid fa-house',
+            'href'      => BASE_PATH . 'index',
+            'data_page' => 'dashboard',
+        ],
+
+        // ─────────────────────────────────────────────────────────────
         // Personal
         // ─────────────────────────────────────────────────────────────
         [

--- a/database/migrations/20260715000002_enable_new_navbar_by_default.php
+++ b/database/migrations/20260715000002_enable_new_navbar_by_default.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Die überarbeitete Sidebar-Navigation (Icon-Rail + Flyout) wird Standard.
+ *
+ * Sie rendert sich deklarativ aus config/navigation.php plus den
+ * Plugin-Fragmenten — Einträge erscheinen und verschwinden damit
+ * automatisch mit dem Plugin-Status, was die handgepflegte Legacy-Sidebar
+ * nie zuverlässig konnte. Der Flag bleibt editierbar als Opt-out für
+ * eine Übergangszeit; danach fällt der Legacy-Zweig in navbar.php weg.
+ */
+class EnableNewNavbarByDefault extends AbstractMigration
+{
+    public function up(): void
+    {
+        $pdo = $this->getAdapter()->getConnection();
+
+        $pdo->exec(
+            "UPDATE intra_config
+             SET config_value = 'true',
+                 description = 'Neue Sidebar-Navigation mit Icon-Rail und aufklappbarem Flyout (Standard; deaktivieren stellt die alte Sidebar wieder her)'
+             WHERE config_key = 'UI_NEW_NAVBAR_ENABLED'"
+        );
+    }
+
+    public function down(): void
+    {
+        $pdo = $this->getAdapter()->getConnection();
+
+        $pdo->exec(
+            "UPDATE intra_config
+             SET config_value = 'false',
+                 description = 'Neue Sidebar-Navigation mit Icon-Rail und aufklappbarem Flyout aktivieren (experimentell)'
+             WHERE config_key = 'UI_NEW_NAVBAR_ENABLED'"
+        );
+    }
+}


### PR DESCRIPTION
Rollout of the icon-rail navigation, as checked earlier today:

- The toggle only swaps the sidebar — topbar (search, notifications, user menu) is shared code and stays identical.
- Mobile works: same `intraSidebar` id, `sidebar-flyout.js` owns the hamburger, the legacy jQuery handler already early-returns under the new navbar.
- Content parity comes from `config/navigation.php` + plugin fragments (KB brings its own rail entry, the protocol plugins merge into *Protokolle*).

Changes:
- Migration flips `UI_NEW_NAVBAR_ENABLED` to `true` and drops the '(experimentell)' wording; the flag stays editable as an opt-out. `down()` restores the old state.
- The rail gains an explicit **Dashboard** entry (the legacy sidebar had one; the logo alone is easy to miss as a home link).

Follow-up after a transition release: delete the ~1,450-line legacy branch in `navbar.php`.