### PR TITLE
More hosting compatibility fixes

### DIFF
--- a/storage/documents/.htaccess
+++ b/storage/documents/.htaccess
@@ -1,15 +1,27 @@
-# Erlaube direkten Zugriff auf PDFs
+# storage/documents/ — nur PDFs sind direkt abrufbar (geteilte Dokument-
+# Links), alles andere bleibt gesperrt.
+#
+# Apache 2.4 verwendet `Require`. Der `Order/Deny`-Block ist der Fallback
+# für Apache 2.2 bzw. Setups mit mod_access_compat — 2.2-Syntax alleine
+# (ohne IfModule-Guard) wirft auf 2.4 ohne access_compat einen 500 für
+# jeden Request in dieses Verzeichnis.
 
 <FilesMatch "\.pdf$">
-Allow from all
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Allow from all
+    </IfModule>
 </FilesMatch>
 
-## Verhindere Verzeichnis-Listing
-
-Options -Indexes
-
-## Verhindere Zugriff auf andere Dateien
-
 <FilesMatch "(?<!\.pdf)$">
-Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
 </FilesMatch>

--- a/tests/.htaccess
+++ b/tests/.htaccess
@@ -1,1 +1,9 @@
-Deny from all
+# tests/ — PHPUnit-Suites, kein direkter HTTP-Zugriff.
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order allow,deny
+    Deny from all
+</IfModule>

--- a/tools/db-migrate.php
+++ b/tools/db-migrate.php
@@ -23,34 +23,56 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $root = dirname(__DIR__);
 
-// Ohne .env (CI-Runner, frischer Clone vor dem Setup) gibt es keine DB-
-// Credentials. Der Hook läuft über Composer post-install/-update — dort darf
-// eine fehlende .env kein FAILURE sein, sonst bricht jeder `composer install`
-// in der CI ab. Migration ist ein reiner Produktiv-Schritt; ohne .env wird
-// sie schlicht übersprungen.
-if (!is_file($root . '/.env')) {
-    fwrite(STDOUT, "[SKIP] Keine .env gefunden — DB-Migration übersprungen (CI/Erstinstallation).\n");
-    exit(0);
-}
-
-try {
-    $dotenv = Dotenv\Dotenv::createImmutable($root);
-    $dotenv->load();
-} catch (\Throwable $e) {
-    fwrite(STDERR, "[FAIL] .env nicht geladen: " . $e->getMessage() . "\n");
-    exit(1);
-}
-
-foreach (['DB_HOST', 'DB_USER', 'DB_PASS', 'DB_NAME'] as $required) {
-    if (!isset($_ENV[$required])) {
-        fwrite(STDERR, "[FAIL] Umgebungsvariable $required fehlt in .env\n");
+// Credentials kommen aus der .env ODER aus echten Umgebungsvariablen —
+// Docker/CI-Setups setzen DB_HOST & Co. direkt in die Prozessumgebung
+// und haben gar keine (oder eine unvollständige) .env.
+if (is_file($root . '/.env')) {
+    try {
+        $dotenv = Dotenv\Dotenv::createImmutable($root);
+        $dotenv->load();
+    } catch (\Throwable $e) {
+        fwrite(STDERR, "[FAIL] .env nicht geladen: " . $e->getMessage() . "\n");
         exit(1);
     }
 }
 
+$env = static function (string $key): ?string {
+    if (isset($_ENV[$key])) {
+        return (string) $_ENV[$key];
+    }
+    if (isset($_SERVER[$key]) && is_string($_SERVER[$key])) {
+        return $_SERVER[$key];
+    }
+    $value = getenv($key);
+    return $value === false ? null : $value;
+};
+
+$db = [];
+$missing = [];
+foreach (['DB_HOST', 'DB_USER', 'DB_PASS', 'DB_NAME'] as $required) {
+    $value = $env($required);
+    if ($value === null) {
+        $missing[] = $required;
+    } else {
+        $db[$required] = $value;
+    }
+}
+
+if ($missing !== []) {
+    // Composer post-install/-update läuft auch in CI-Runnern und auf frischen
+    // Clones vor dem Setup — dort darf das kein FAILURE sein, sonst bricht
+    // jeder `composer install` ab. Migration ist ein reiner Produktiv-Schritt.
+    if (count($missing) === 4) {
+        fwrite(STDOUT, "[SKIP] Keine DB-Credentials (.env oder Umgebungsvariablen) — Migration übersprungen (CI/Erstinstallation).\n");
+        exit(0);
+    }
+    fwrite(STDERR, "[FAIL] Unvollständige DB-Credentials, es fehlt: " . implode(', ', $missing) . "\n");
+    exit(1);
+}
+
 try {
-    $dsn = "mysql:host={$_ENV['DB_HOST']};dbname={$_ENV['DB_NAME']};charset=utf8mb4";
-    $pdo = new PDO($dsn, $_ENV['DB_USER'], $_ENV['DB_PASS'], [
+    $dsn = "mysql:host={$db['DB_HOST']};dbname={$db['DB_NAME']};charset=utf8mb4";
+    $pdo = new PDO($dsn, $db['DB_USER'], $db['DB_PASS'], [
         PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
     ]);
 } catch (\PDOException $e) {
@@ -59,8 +81,8 @@ try {
 }
 
 echo "ıgnıs Migration\n";
-echo "  Host:     {$_ENV['DB_HOST']}\n";
-echo "  Database: {$_ENV['DB_NAME']}\n";
+echo "  Host:     {$db['DB_HOST']}\n";
+echo "  Database: {$db['DB_NAME']}\n";
 echo "  Driver:   Phinx (mit Legacy-Bridge)\n\n";
 
 $migrator = new App\Database\AutoMigrator($pdo);


### PR DESCRIPTION
Follow-up to the MultiViews fix from #337 — same class of problem, found while sweeping for setups that work on our stack but silently break elsewhere.

**storage/documents/.htaccess & tests/.htaccess** still used bare Apache 2.2 syntax (`Allow`/`Deny` without IfModule guards). On Apache 2.4 without `mod_access_compat` that turns into a 500 for every request into those directories — meaning every shared PDF link dies with no useful error. Both now use the dual-syntax pattern the other blocking .htaccess files already had. The per-directory `Options -Indexes` is gone too; it required `AllowOverride Options` (same 500 trap as MultiViews) and the root .htaccess already prevents listing.

**tools/db-migrate.php** insisted on a .env file and only read `$_ENV`, so Docker/CI setups that pass DB credentials through the process environment failed with "DB_HOST fehlt in .env". Credentials now fall back to `$_SERVER`/`getenv()`, and the skip behaviour for composer hooks on fresh clones is unchanged.

Verified in the Docker stack: PDFs serve with 200, everything else in the directory 403s, and the entrypoint migration now actually runs with compose-provided env vars (it never did before).